### PR TITLE
Add PORT env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project uses Ktor with MongoDB. The service periodically pulls Rust servers
 
 ## Running
 
-Ensure MongoDB is accessible and set `MONGODB_URI` if needed. Then start the server:
+Ensure MongoDB is accessible and set `MONGODB_URI` if needed. You can also set `PORT` to change the listening port (defaults to `8080`). Then start the server:
 
 ```
 ./gradlew run

--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -38,7 +38,8 @@ import pl.cuyer.thedome.resources.Servers
 
 
 fun main() {
-    embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)
+    val port = System.getenv("PORT")?.toIntOrNull() ?: 8080
+    embeddedServer(Netty, port = port, module = Application::module).start(wait = true)
 }
 
 fun Application.module() {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,6 +1,7 @@
 ktor {
     deployment {
-        port = 8080
+        # Port is configured via the PORT environment variable
+        port = ${?PORT}
     }
     application {
         modules = [ pl.cuyer.thedome.ApplicationKt.module ]


### PR DESCRIPTION
## Summary
- make `main()` read the `PORT` environment variable
- look for `PORT` in `application.conf`
- note new variable in README

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68514863cdf08321a17938c373bf526e