### PR TITLE
Add unit tests for server utilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,4 +37,7 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
 }

--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsTest.kt
@@ -1,0 +1,33 @@
+package pl.cuyer.thedome.domain.battlemetrics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import pl.cuyer.thedome.domain.rust.RustMaps
+
+class ServerExtensionsTest {
+    private fun serverWithUrl(url: String?): BattlemetricsServerContent {
+        val rustMaps = if (url != null) RustMaps(thumbnailUrl = url) else null
+        val details = Details(rustMaps = rustMaps)
+        val attributes = Attributes(id = "1", details = details)
+        return BattlemetricsServerContent(attributes = attributes, id = "1")
+    }
+
+    @Test
+    fun `extractMapId handles lowercase path`() {
+        val server = serverWithUrl("https://example.com/maps/abc123/thumbnail.png")
+        assertEquals("abc123", server.extractMapId())
+    }
+
+    @Test
+    fun `extractMapId handles capital Thumbnail`() {
+        val server = serverWithUrl("https://example.com/maps/XYZ/Thumbnail.jpg")
+        assertEquals("XYZ", server.extractMapId())
+    }
+
+    @Test
+    fun `extractMapId returns null without url`() {
+        val server = serverWithUrl(null)
+        assertNull(server.extractMapId())
+    }
+}

--- a/src/test/kotlin/pl/cuyer/thedome/domain/server/WipeScheduleTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/server/WipeScheduleTest.kt
@@ -1,0 +1,37 @@
+package pl.cuyer.thedome.domain.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import pl.cuyer.thedome.domain.rust.Wipe
+
+class WipeScheduleTest {
+    @Test
+    fun `empty list returns null`() {
+        assertNull(WipeSchedule.from(emptyList()))
+    }
+
+    @Test
+    fun `one flag returns MONTHLY`() {
+        val wipes = listOf(Wipe(weeks = listOf(1)))
+        assertEquals(WipeSchedule.MONTHLY, WipeSchedule.from(wipes))
+    }
+
+    @Test
+    fun `five flags returns WEEKLY`() {
+        val wipes = listOf(Wipe(weeks = listOf(1,1,1,1,1)))
+        assertEquals(WipeSchedule.WEEKLY, WipeSchedule.from(wipes))
+    }
+
+    @Test
+    fun `ten flags returns BIWEEKLY`() {
+        val wipes = listOf(Wipe(weeks = List(10) { 1 }))
+        assertEquals(WipeSchedule.BIWEEKLY, WipeSchedule.from(wipes))
+    }
+
+    @Test
+    fun `other flag counts return null`() {
+        val wipes = listOf(Wipe(weeks = listOf(1,1,1)))
+        assertNull(WipeSchedule.from(wipes))
+    }
+}


### PR DESCRIPTION
## Summary
- create `src/test/kotlin` structure
- add tests for `WipeSchedule.from`
- add tests for `BattlemetricsServerContent.extractMapId`
- log passed/failed test events in Gradle `test` task

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685148726680832188ce74126ea2cfac