### PR TITLE
Add StatusPages plugin for error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Environment variables:
 - `FETCH_DELAY_MS` – fetch interval in milliseconds
 - `API_KEY` – optional RustMaps API key
 - `PORT` – overrides the default port if implemented
+- Unhandled exceptions are logged via Ktor's `StatusPages` plugin
 
 Query servers with optional `page` and `size` parameters:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-resources-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-status-pages-jvm:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-cio-jvm:$ktorVersion")

--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -18,6 +18,8 @@ import io.ktor.client.request.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import io.ktor.serialization.kotlinx.json.*
+import io.ktor.http.*
+import io.ktor.server.plugins.statuspages.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -47,6 +49,12 @@ fun Application.module() {
         json(Json { ignoreUnknownKeys = true })
     }
     install(Resources)
+    install(StatusPages) {
+        exception<Throwable> { call, cause ->
+            call.application.log.error("Unhandled exception", cause)
+            call.respond(HttpStatusCode.InternalServerError)
+        }
+    }
 
     val mongoUri = System.getenv("MONGODB_URI") ?: "mongodb://localhost:27017"
     val client = KMongo.createClient(mongoUri).coroutine

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- enable ktor-server-status-pages plugin
- add global exception logging and server error responses
- provide logback configuration for console logging
- mention new exception logging in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6851567dbbbc8321911a2ff5eee5aa89