### PR TITLE
Add server filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,26 @@ Environment variables:
 - `PORT` – overrides the default port if implemented
 - Unhandled exceptions are logged via Ktor's `StatusPages` plugin
 
-Query servers with optional `page` and `size` parameters:
+Query servers with optional filtering. Alongside pagination (`page` and `size`),
+the following parameters can be used:
+
+- `map` – map type
+- `flag` – country code
+- `region` – server region
+- `difficulty` – server difficulty
+- `modded` – modded servers only when `true`
+- `official` – official servers only when `true`
+- `wipeSchedule` – wipe schedule
+- `rank` – server rank
+- `player_count` – current player count
+- `server_capacity` – maximum players count
+- `order` – ordering field (`WIPE`, `RANK`, `PLAYER_COUNT`; defaults to `WIPE`)
+
+
+Example request:
 
 ```
-GET http://localhost:8080/servers?page=1&size=20
+GET http://localhost:8080/servers?page=1&size=20&region=EUROPE&order=PLAYER_COUNT
 ```
 
 ## Docker

--- a/src/main/kotlin/pl/cuyer/thedome/domain/server/Order.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/server/Order.kt
@@ -1,0 +1,10 @@
+package pl.cuyer.thedome.domain.server
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class Order {
+    WIPE,
+    RANK,
+    PLAYER_COUNT
+}

--- a/src/main/kotlin/pl/cuyer/thedome/resources/Servers.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/resources/Servers.kt
@@ -1,8 +1,31 @@
 package pl.cuyer.thedome.resources
 
 import io.ktor.resources.Resource
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import pl.cuyer.thedome.domain.server.Difficulty
+import pl.cuyer.thedome.domain.server.Flag
+import pl.cuyer.thedome.domain.server.Maps
+import pl.cuyer.thedome.domain.server.Region
+import pl.cuyer.thedome.domain.server.WipeSchedule
+import pl.cuyer.thedome.domain.server.Order
 
 @Serializable
 @Resource("/servers")
-data class Servers(val page: Int? = null, val size: Int? = null)
+data class Servers(
+    val page: Int? = null,
+    val size: Int? = null,
+    val map: Maps? = null,
+    val flag: Flag? = null,
+    val region: Region? = null,
+    val difficulty: Difficulty? = null,
+    val modded: Boolean? = null,
+    val official: Boolean? = null,
+    val wipeSchedule: WipeSchedule? = null,
+    val rank: Int? = null,
+    @SerialName("player_count")
+    val playerCount: Int? = null,
+    @SerialName("server_capacity")
+    val serverCapacity: Int? = null,
+    val order: Order? = null
+)

--- a/src/main/kotlin/pl/cuyer/thedome/routes/ServersEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/ServersEndpoint.kt
@@ -1,0 +1,18 @@
+package pl.cuyer.thedome.routes
+
+import io.ktor.server.application.*
+import io.ktor.server.resources.get
+import io.ktor.server.response.*
+import io.ktor.server.routing.Route
+import pl.cuyer.thedome.resources.Servers
+import pl.cuyer.thedome.services.ServersService
+
+class ServersEndpoint(private val service: ServersService) {
+    fun register(route: Route) {
+        with(route) {
+            get<Servers> { params ->
+                call.respond(service.getServers(params))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/pl/cuyer/thedome/services/ServersService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/ServersService.kt
@@ -1,0 +1,62 @@
+package pl.cuyer.thedome.services
+
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Sorts
+import org.bson.conversions.Bson
+import org.litote.kmongo.coroutine.CoroutineCollection
+import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
+import pl.cuyer.thedome.domain.battlemetrics.toServerInfo
+import pl.cuyer.thedome.domain.server.Order
+import pl.cuyer.thedome.domain.server.ServerInfo
+import pl.cuyer.thedome.resources.Servers
+import java.util.regex.Pattern
+
+class ServersService(private val collection: CoroutineCollection<BattlemetricsServerContent>) {
+    suspend fun getServers(params: Servers): List<ServerInfo> {
+        val page = params.page ?: 1
+        val size = params.size ?: 20
+        val skip = (page - 1) * size
+
+        val filters = mutableListOf<Bson>()
+        params.map?.let {
+            val pattern = Pattern.compile(it.name.replace('_', ' '), Pattern.CASE_INSENSITIVE)
+            filters += Filters.regex("attributes.details.map", pattern)
+        }
+        params.flag?.let { filters += Filters.eq("attributes.country", it.name) }
+        params.region?.let {
+            val pattern = Pattern.compile("^${it.name}", Pattern.CASE_INSENSITIVE)
+            filters += Filters.regex("attributes.details.rustSettings.timezone", pattern)
+        }
+        params.difficulty?.let {
+            val pattern = Pattern.compile(it.name, Pattern.CASE_INSENSITIVE)
+            filters += Filters.regex("attributes.details.rustGamemode", pattern)
+        }
+        params.modded?.let { modded ->
+            val pattern = Pattern.compile("modded", Pattern.CASE_INSENSITIVE)
+            val regexFilter = Filters.regex("attributes.details.rustType", pattern)
+            filters += if (modded) regexFilter else Filters.not(regexFilter)
+        }
+        params.official?.let { filters += Filters.eq("attributes.details.official", it) }
+        params.rank?.let { filters += Filters.eq("attributes.rank", it) }
+        params.playerCount?.let { filters += Filters.eq("attributes.players", it) }
+        params.serverCapacity?.let { filters += Filters.eq("attributes.maxPlayers", it) }
+
+        val sortField = when (params.order) {
+            Order.RANK -> "attributes.rank"
+            Order.PLAYER_COUNT -> "attributes.players"
+            else -> "attributes.details.rustLastWipe"
+        }
+        val sort = if (params.order == Order.RANK) Sorts.ascending(sortField) else Sorts.descending(sortField)
+
+        val query = if (filters.isEmpty()) collection.find() else collection.find(Filters.and(filters))
+
+        val serverInfos = query
+            .sort(sort)
+            .skip(skip)
+            .limit(size)
+            .toList()
+            .map { it.toServerInfo() }
+
+        return serverInfos.filter { params.wipeSchedule == null || it.wipeSchedule == params.wipeSchedule }
+    }
+}

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -17,6 +17,61 @@ paths:
           schema:
             type: integer
           required: false
+        - in: query
+          name: map
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: flag
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: region
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: difficulty
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: modded
+          schema:
+            type: boolean
+          required: false
+        - in: query
+          name: official
+          schema:
+            type: boolean
+          required: false
+        - in: query
+          name: wipeSchedule
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: rank
+          schema:
+            type: integer
+          required: false
+        - in: query
+          name: player_count
+          schema:
+            type: integer
+          required: false
+        - in: query
+          name: server_capacity
+          schema:
+            type: integer
+          required: false
+        - in: query
+          name: order
+          schema:
+            type: string
+          required: false
       responses:
         '200':
           description: List of servers


### PR DESCRIPTION
## Summary
- extend Servers resource to include wipe schedule, rank, player count and order parameters
- filter servers using new query params and allow ordering (defaulting to wipe time)
- document new parameters in README and OpenAPI spec
- separate server retrieval into service and endpoint classes
- add filter for maximum player capacity

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6851819a96388321b853e44336498bf4