### PR TITLE
Add filter options endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TheDome backend
 
-This project uses Ktor with MongoDB. The service periodically pulls Rust servers from the Battlemetrics API, saves them into MongoDB and exposes `/servers` endpoint which returns servers sorted by rank with pagination metadata. Scheduled tasks are managed using the Ktor Task Scheduling plugin. Dependencies are wired using the Koin library.
+This project uses Ktor with MongoDB. The service periodically pulls Rust servers from the Battlemetrics API, saves them into MongoDB and exposes `/servers` endpoint which returns servers sorted by rank with pagination metadata. It also provides `/filters/options` for querying available filter values. Scheduled tasks are managed using the Ktor Task Scheduling plugin. Dependencies are wired using the Koin library.
 
 ## Running
 
@@ -97,6 +97,7 @@ This will start two containers:
 - `mongo` (MongoDB) on port `27017`
 
 The application will be available at `http://localhost:8080/servers`.
+Filter options can be fetched from `http://localhost:8080/filters/options`.
 
 ### Ports
 - Application: `8080` (exposed on host)
@@ -122,6 +123,7 @@ docker compose up --build
 ```
 
 The backend will be available at `http://localhost:8080/servers`.
+You can retrieve filter options at `http://localhost:8080/filters/options`.
 
 ## Development
 

--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -26,7 +26,9 @@ import pl.cuyer.thedome.domain.battlemetrics.*
 import pl.cuyer.thedome.resources.Servers
 import pl.cuyer.thedome.services.ServerFetchService
 import pl.cuyer.thedome.services.ServersService
+import pl.cuyer.thedome.services.FiltersService
 import pl.cuyer.thedome.routes.ServersEndpoint
+import pl.cuyer.thedome.routes.FiltersEndpoint
 import org.koin.ktor.plugin.Koin
 import org.koin.ktor.ext.inject
 import org.koin.logger.slf4jLogger
@@ -98,10 +100,13 @@ fun Application.module() {
     }
 
     val serversService by inject<ServersService>()
+    val filtersService by inject<FiltersService>()
     val serversEndpoint = ServersEndpoint(serversService)
+    val filtersEndpoint = FiltersEndpoint(filtersService)
 
     routing {
         serversEndpoint.register(this)
+        filtersEndpoint.register(this)
         swaggerUI(path = "swagger")
     }
 }

--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -15,6 +15,7 @@ import org.koin.dsl.module
 import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
 import pl.cuyer.thedome.services.ServerFetchService
 import pl.cuyer.thedome.services.ServersService
+import pl.cuyer.thedome.services.FiltersService
 
 val appModule = module {
     single<Json> { Json { ignoreUnknownKeys = true } }
@@ -49,4 +50,5 @@ val appModule = module {
 
     single { ServerFetchService(get(), get()) }
     single { ServersService(get()) }
+    single { FiltersService(get()) }
 }

--- a/src/main/kotlin/pl/cuyer/thedome/domain/server/FiltersOptions.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/server/FiltersOptions.kt
@@ -1,0 +1,20 @@
+package pl.cuyer.thedome.domain.server
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FiltersOptions(
+    val flags: List<Flag>,
+    @SerialName("max_ranking")
+    val maxRanking: Int,
+    @SerialName("max_player_count")
+    val maxPlayerCount: Int,
+    @SerialName("max_group_limit")
+    val maxGroupLimit: Int,
+    val maps: List<Maps>,
+    val regions: List<Region>,
+    val difficulty: List<Difficulty>,
+    @SerialName("wipe_schedules")
+    val wipeSchedules: List<WipeSchedule>
+)

--- a/src/main/kotlin/pl/cuyer/thedome/resources/FiltersOptions.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/resources/FiltersOptions.kt
@@ -1,0 +1,8 @@
+package pl.cuyer.thedome.resources
+
+import io.ktor.resources.Resource
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Resource("/filters/options")
+class FiltersOptions

--- a/src/main/kotlin/pl/cuyer/thedome/routes/FiltersEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/FiltersEndpoint.kt
@@ -1,0 +1,18 @@
+package pl.cuyer.thedome.routes
+
+import io.ktor.server.application.*
+import io.ktor.server.resources.get
+import io.ktor.server.response.*
+import io.ktor.server.routing.Route
+import pl.cuyer.thedome.resources.FiltersOptions
+import pl.cuyer.thedome.services.FiltersService
+
+class FiltersEndpoint(private val service: FiltersService) {
+    fun register(route: Route) {
+        with(route) {
+            get<FiltersOptions> {
+                call.respond(service.getOptions())
+            }
+        }
+    }
+}

--- a/src/main/kotlin/pl/cuyer/thedome/services/FiltersService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/FiltersService.kt
@@ -1,0 +1,32 @@
+package pl.cuyer.thedome.services
+
+import org.litote.kmongo.coroutine.CoroutineCollection
+import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
+import pl.cuyer.thedome.domain.battlemetrics.toServerInfo
+import pl.cuyer.thedome.domain.server.*
+
+class FiltersService(private val collection: CoroutineCollection<BattlemetricsServerContent>) {
+    suspend fun getOptions(): FiltersOptions {
+        val servers = collection.find().toList().map { it.toServerInfo() }
+
+        val flags = servers.mapNotNull { it.serverFlag }.distinct().sortedBy { it.name }
+        val maxRanking = servers.mapNotNull { it.ranking?.toInt() }.maxOrNull() ?: 0
+        val maxPlayerCount = servers.mapNotNull { it.playerCount?.toInt() }.maxOrNull() ?: 0
+        val maxGroupLimit = servers.mapNotNull { it.maxGroup?.toInt() }.maxOrNull() ?: 0
+        val maps = servers.mapNotNull { it.mapName }.distinct().sortedBy { it.name }
+        val regions = servers.mapNotNull { it.region }.distinct().sortedBy { it.name }
+        val difficulty = servers.mapNotNull { it.difficulty }.distinct().sortedBy { it.name }
+        val wipeSchedules = servers.mapNotNull { it.wipeSchedule }.distinct().sortedBy { it.name }
+
+        return FiltersOptions(
+            flags = flags,
+            maxRanking = maxRanking,
+            maxPlayerCount = maxPlayerCount,
+            maxGroupLimit = maxGroupLimit,
+            maps = maps,
+            regions = regions,
+            difficulty = difficulty,
+            wipeSchedules = wipeSchedules
+        )
+    }
+}

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -79,6 +79,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServersResponse'
+  /filters/options:
+    get:
+      summary: Available filter options
+      responses:
+        '200':
+          description: Filter options
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FiltersOptions'
 components:
   schemas:
     ServerInfo:
@@ -138,3 +148,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ServerInfo'
+    FiltersOptions:
+      type: object
+      properties:
+        flags:
+          type: array
+          items:
+            type: string
+        max_ranking:
+          type: integer
+        max_player_count:
+          type: integer
+        max_group_limit:
+          type: integer
+        maps:
+          type: array
+          items:
+            type: string
+        regions:
+          type: array
+          items:
+            type: string
+        difficulty:
+          type: array
+          items:
+            type: string
+        wipe_schedules:
+          type: array
+          items:
+            type: string

--- a/src/test/kotlin/pl/cuyer/thedome/services/FiltersServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/FiltersServiceTest.kt
@@ -1,0 +1,58 @@
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.litote.kmongo.coroutine.CoroutineCollection
+import org.litote.kmongo.coroutine.CoroutineFindPublisher
+import pl.cuyer.thedome.domain.battlemetrics.*
+import pl.cuyer.thedome.domain.rust.RustMaps
+import pl.cuyer.thedome.domain.rust.RustSettings
+import pl.cuyer.thedome.domain.rust.Wipe
+import pl.cuyer.thedome.domain.server.*
+import pl.cuyer.thedome.services.FiltersService
+
+class FiltersServiceTest {
+    @Test
+    fun `getOptions aggregates distinct values`() = runBlocking {
+        val settings1 = RustSettings(groupLimit = 5, wipes = listOf(Wipe(weeks = listOf(1))), timezone = "Europe/London")
+        val rustMaps1 = RustMaps(thumbnailUrl = null, imageIconUrl = null)
+        val details1 = Details(
+            map = "Procedural Map",
+            rustGamemode = "vanilla",
+            rustSettings = settings1,
+            rustMaps = rustMaps1
+        )
+        val attr1 = Attributes(country = "GB", details = details1, id = "1", players = 10, rank = 3)
+        val server1 = BattlemetricsServerContent(attributes = attr1, id = "1")
+
+        val settings2 = RustSettings(groupLimit = 8, wipes = listOf(Wipe(weeks = List(10) { 1 })), timezone = "America/New_York")
+        val rustMaps2 = RustMaps(thumbnailUrl = null, imageIconUrl = null)
+        val details2 = Details(
+            map = "Barren",
+            rustGamemode = "softcore",
+            rustSettings = settings2,
+            rustMaps = rustMaps2
+        )
+        val attr2 = Attributes(country = "US", details = details2, id = "2", players = 50, rank = 1)
+        val server2 = BattlemetricsServerContent(attributes = attr2, id = "2")
+
+        val publisher = mockk<CoroutineFindPublisher<BattlemetricsServerContent>>()
+        val collection = mockk<CoroutineCollection<BattlemetricsServerContent>>()
+        every { collection.find() } returns publisher
+        coEvery { publisher.toList() } returns listOf(server1, server2)
+
+        val service = FiltersService(collection)
+        val options = service.getOptions()
+
+        assertEquals(listOf(Flag.GB, Flag.US), options.flags)
+        assertEquals(3, options.maxRanking)
+        assertEquals(50, options.maxPlayerCount)
+        assertEquals(8, options.maxGroupLimit)
+        assertEquals(listOf(Maps.BARREN, Maps.PROCEDURAL), options.maps)
+        assertEquals(listOf(Region.AMERICA, Region.EUROPE), options.regions)
+        assertEquals(listOf(Difficulty.SOFTCORE, Difficulty.VANILLA), options.difficulty)
+        assertEquals(listOf(WipeSchedule.BIWEEKLY, WipeSchedule.MONTHLY), options.wipeSchedules)
+    }
+}


### PR DESCRIPTION
## Summary
- implement `FiltersServiceTest` for options logic
- update OpenAPI with `/filters/options` specification
- document new filter endpoint in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685322c0c8c48321a93f7c6d10748d1a