### PR TITLE
Map rust gamemode value

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/services/ServerFetchService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/ServerFetchService.kt
@@ -41,10 +41,17 @@ class ServerFetchService(
                                 iconCache.getOrPut(mapId) { client.fetchMapIcon(mapId, apiKey) }
                             } else null
 
-                            val rustMaps = server.attributes.details?.rustMaps
                             val details = server.attributes.details
+                            val rustMaps = details?.rustMaps
                             val newRustMaps = if (iconUrl != null) rustMaps?.copy(imageIconUrl = iconUrl) else rustMaps
-                            val newDetails = details?.copy(rustMaps = newRustMaps)
+                            val newGamemode = when (details?.rustGamemode?.lowercase()) {
+                                "rust" -> "vanilla"
+                                else -> details?.rustGamemode
+                            }
+                            val newDetails = details?.copy(
+                                rustMaps = newRustMaps,
+                                rustGamemode = newGamemode
+                            )
                             server.copy(attributes = server.attributes.copy(details = newDetails))
                         }
                     }.awaitAll()

--- a/src/test/kotlin/pl/cuyer/thedome/services/ServerFetchServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/ServerFetchServiceTest.kt
@@ -52,4 +52,32 @@ class ServerFetchServiceTest {
         assertEquals(setOf("1", "2"), ids)
         coVerify(exactly = 1) { collection.deleteMany(any<Bson>(), any<DeleteOptions>()) }
     }
+
+    @Test
+    fun `fetchServers maps rust gamemode rust to vanilla`() = runBlocking {
+        val details = Details(rustGamemode = "rust")
+        val attributes = Attributes(id = "a1", details = details)
+        val server = BattlemetricsServerContent(attributes = attributes, id = "1")
+        val page = BattlemetricsPage(data = listOf(server), links = Links(null))
+
+        val engine = MockEngine { request ->
+            respond(
+                content = ByteReadChannel(json.encodeToString(page)),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
+
+        val collection = mockk<CoroutineCollection<BattlemetricsServerContent>>()
+        val slotOps = slot<List<ReplaceOneModel<BattlemetricsServerContent>>>()
+        coEvery { collection.bulkWrite(capture(slotOps), any<BulkWriteOptions>()) } returns mockk()
+        coEvery { collection.deleteMany(any<Bson>()) } returns mockk()
+
+        val service = ServerFetchService(client, collection)
+        service.fetchServers()
+
+        val gamemode = slotOps.captured.first().replacement.attributes.details?.rustGamemode
+        assertEquals("vanilla", gamemode)
+    }
 }


### PR DESCRIPTION
## Summary
- normalize the `rust_gamemode` field during fetch
- test the gamemode normalization

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685476e4053883218e3f5de0de583eab