### PR TITLE
Expose status and wipe type

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ The response includes the requested page of servers and pagination fields:
   "servers": [ ... ]
 }
 ```
+Each server entry also exposes:
+
+- `status` – the current server status
+- `wipe_type` – type of the most recent wipe
 
 ## Docker
 

--- a/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
@@ -32,8 +32,11 @@ fun BattlemetricsServerContent.toServerInfo(): ServerInfo =
         id = id.toLongOrNull(),
         name = attributes.name,
         wipe = attributes.details?.rustLastWipe?.let(Instant::parse),
+        status = attributes.status,
         ranking = attributes.rank,
-        modded = attributes.details?.rustType?.contains("modded"),
+        modded = attributes.details?.rustType?.let {
+            it.contains("modded", ignoreCase = true) || it.contains("community", ignoreCase = true)
+        },
         playerCount = attributes.players?.toLong(),
         serverCapacity = attributes.maxPlayers?.toLong(),
         mapName = attributes.details?.map?.substringBefore(" ")?.uppercase()?.let {
@@ -66,6 +69,7 @@ fun BattlemetricsServerContent.toServerInfo(): ServerInfo =
         serverIp = ipPort(attributes.ip ?: "", attributes.port?.toString() ?: ""),
         mapImage = attributes.details?.rustMaps?.imageIconUrl,
         description = attributes.details?.rustDescription,
+        wipeType = attributes.details?.rustWipes?.firstOrNull()?.type,
     )
 
 private fun calculateCycle(wipes: List<RustWipe>): Double? {

--- a/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
@@ -9,6 +9,7 @@ data class ServerInfo(
     val id: Long? = null,
     val name: String? = null,
     val wipe: Instant? = null,
+    val status: String? = null,
     val ranking: Int? = null,
     val modded: Boolean? = null,
     @SerialName("player_count")
@@ -30,5 +31,7 @@ data class ServerInfo(
     val serverIp: String? = null,
     @SerialName("map_image")
     val mapImage: String? = null,
-    val description: String? = null
+    val description: String? = null,
+    @SerialName("wipe_type")
+    val wipeType: String? = null
 )

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -101,6 +101,8 @@ components:
         wipe:
           type: string
           format: date-time
+        status:
+          type: string
         ranking:
           type: integer
         modded:
@@ -131,6 +133,8 @@ components:
         map_image:
           type: string
         description:
+          type: string
+        wipe_type:
           type: string
     ServersResponse:
       type: object

--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
@@ -66,6 +66,7 @@ class ServerExtensionsAdditionalTest {
             name = "Test",
             ip = "1.1.1.1",
             port = 28015,
+            status = "online",
             players = 10,
             maxPlayers = 50,
             rank = 1,
@@ -91,5 +92,16 @@ class ServerExtensionsAdditionalTest {
         assertEquals(true, info.isOfficial)
         assertEquals("1.1.1.1:28015", info.serverIp)
         assertEquals("icon.png", info.mapImage)
+        assertEquals("online", info.status)
+        assertEquals("map", info.wipeType)
+    }
+
+    @Test
+    fun `community rust type is considered modded`() {
+        val details = Details(rustType = "community")
+        val attributes = Attributes(id = "1", details = details)
+        val server = BattlemetricsServerContent(attributes = attributes, id = "1")
+        val info = server.toServerInfo()
+        assertEquals(true, info.modded)
     }
 }


### PR DESCRIPTION
## Summary
- map community rust type as modded
- expose server status and wipe type in ServerInfo
- map new fields in `BattlemetricsServerContent.toServerInfo`
- test new mappings
- document status and wipe_type in swagger and README

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68547a82848c8321a953d0adc5ff2498