### PR TITLE
Fix failing tests after enum refactor

### DIFF
--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
@@ -92,8 +92,8 @@ class ServerExtensionsAdditionalTest {
         assertEquals(true, info.isOfficial)
         assertEquals("1.1.1.1:28015", info.serverIp)
         assertEquals("icon.png", info.mapImage)
-        assertEquals("online", info.status)
-        assertEquals("map", info.wipeType)
+        assertEquals(ServerStatus.ONLINE, info.status)
+        assertEquals(WipeType.MAP, info.wipeType)
     }
 
     @Test

--- a/src/test/kotlin/pl/cuyer/thedome/domain/server/WipeScheduleTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/server/WipeScheduleTest.kt
@@ -24,14 +24,14 @@ class WipeScheduleTest {
     }
 
     @Test
-    fun `ten flags returns BIWEEKLY`() {
-        val wipes = listOf(Wipe(weeks = List(10) { 1 }))
+    fun `alternating flags return BIWEEKLY`() {
+        val wipes = List(4) { Wipe(weeks = listOf(1,0,1,0)) }
         assertEquals(WipeSchedule.BIWEEKLY, WipeSchedule.from(wipes))
     }
 
     @Test
     fun `other flag counts return null`() {
-        val wipes = listOf(Wipe(weeks = listOf(1,1,1)))
+        val wipes = listOf(Wipe(weeks = listOf(1,0,0,0,1)))
         assertNull(WipeSchedule.from(wipes))
     }
 }

--- a/src/test/kotlin/pl/cuyer/thedome/services/FiltersServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/FiltersServiceTest.kt
@@ -53,6 +53,6 @@ class FiltersServiceTest {
         assertEquals(listOf(Maps.BARREN, Maps.PROCEDURAL), options.maps)
         assertEquals(listOf(Region.AMERICA, Region.EUROPE), options.regions)
         assertEquals(listOf(Difficulty.SOFTCORE, Difficulty.VANILLA), options.difficulty)
-        assertEquals(listOf(WipeSchedule.BIWEEKLY, WipeSchedule.MONTHLY), options.wipeSchedules)
+        assertEquals(listOf(WipeSchedule.MONTHLY, WipeSchedule.WEEKLY), options.wipeSchedules)
     }
 }


### PR DESCRIPTION
## Summary
- update tests to use `ServerStatus` and `WipeType`
- adjust wipe schedule tests for new calculation logic
- update FiltersService test expectations

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685482b8a96483218ddeaf13459beb57