### PR TITLE
Add extra server details

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ the following parameters can be used:
 - `groupLimit` – maximum group limit
 - `order` – ordering field (`WIPE`, `RANK`, `PLAYER_COUNT`; defaults to `WIPE`)
 - `name` – substring match on server name
+- `blueprints` – blueprint availability
+- `kits` – kits availability
+- `decay` – decay rate
+- `upkeep` – upkeep cost
+- `rates` – gather rate
+- `seed` – world seed
+- `mapSize` – map size
+- `entityCount` – entity count
+- `monuments` – monument count
 
 
 Example request:

--- a/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
@@ -83,6 +83,15 @@ fun BattlemetricsServerContent.toServerInfo(): ServerInfo =
                 null
             }
         },
+        blueprints = attributes.details?.rustSettings?.blueprints,
+        kits = attributes.details?.rustSettings?.kits,
+        decay = attributes.details?.rustSettings?.decay,
+        upkeep = attributes.details?.rustSettings?.upkeep,
+        rates = attributes.details?.rustSettings?.rates?.gather?.toInt(),
+        seed = attributes.details?.rustWorldSeed?.toInt() ?: attributes.details?.rustMaps?.seed,
+        mapSize = attributes.details?.rustWorldSize ?: attributes.details?.rustMaps?.size,
+        entityCount = attributes.details?.rustFpsAvg,
+        monuments = attributes.details?.rustMaps?.monumentCount,
     )
 
 private fun calculateCycle(wipes: List<RustWipe>): Double? {

--- a/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
@@ -33,5 +33,16 @@ data class ServerInfo(
     val mapImage: String? = null,
     val description: String? = null,
     @SerialName("wipe_type")
-    val wipeType: WipeType? = null
+    val wipeType: WipeType? = null,
+    val blueprints: Boolean? = null,
+    val kits: Boolean? = null,
+    val decay: Float? = null,
+    val upkeep: Double? = null,
+    val rates: Int? = null,
+    val seed: Int? = null,
+    @SerialName("map_size")
+    val mapSize: Int? = null,
+    @SerialName("entity_count")
+    val entityCount: Double? = null,
+    val monuments: Int? = null
 )

--- a/src/main/kotlin/pl/cuyer/thedome/resources/Servers.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/resources/Servers.kt
@@ -25,5 +25,14 @@ data class Servers(
     val playerCount: Int? = null,
     val groupLimit: Int? = null,
     val order: Order? = null,
-    val name: String? = null
+    val name: String? = null,
+    val blueprints: String? = null,
+    val kits: String? = null,
+    val decay: Float? = null,
+    val upkeep: Float? = null,
+    val rates: Int? = null,
+    val seed: Int? = null,
+    val mapSize: Int? = null,
+    val entityCount: Double? = null,
+    val monuments: Int? = null,
 )

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -77,6 +77,51 @@ paths:
           schema:
             type: string
           required: false
+        - in: query
+          name: blueprints
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: kits
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: decay
+          schema:
+            type: number
+          required: false
+        - in: query
+          name: upkeep
+          schema:
+            type: number
+          required: false
+        - in: query
+          name: rates
+          schema:
+            type: integer
+          required: false
+        - in: query
+          name: seed
+          schema:
+            type: integer
+          required: false
+        - in: query
+          name: mapSize
+          schema:
+            type: integer
+          required: false
+        - in: query
+          name: entityCount
+          schema:
+            type: number
+          required: false
+        - in: query
+          name: monuments
+          schema:
+            type: integer
+          required: false
       responses:
         '200':
           description: List of servers
@@ -141,6 +186,27 @@ components:
           type: string
         wipe_type:
           type: string
+        blueprints:
+          type: boolean
+        kits:
+          type: boolean
+        decay:
+          type: number
+          format: float
+        upkeep:
+          type: number
+          format: double
+        rates:
+          type: integer
+        seed:
+          type: integer
+        map_size:
+          type: integer
+        entity_count:
+          type: number
+          format: double
+        monuments:
+          type: integer
     ServersResponse:
       type: object
       properties:

--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
@@ -49,8 +49,23 @@ class ServerExtensionsAdditionalTest {
             RustWipe(timestamp = "2024-01-01T00:00:00Z", type = "map"),
             RustWipe(timestamp = "2024-01-04T00:00:00Z", type = "map")
         )
-        val settings = RustSettings(timezone = "Europe/London", groupLimit = 5, wipes = listOf(Wipe(weeks = listOf(1))))
-        val rustMaps = RustMaps(thumbnailUrl = "https://example.com/maps/abc/thumbnail.png", imageIconUrl = "icon.png")
+        val settings = RustSettings(
+            timezone = "Europe/London",
+            groupLimit = 5,
+            wipes = listOf(Wipe(weeks = listOf(1))),
+            blueprints = true,
+            kits = true,
+            decay = 0.5f,
+            upkeep = 1.0,
+            rates = Rates(gather = 3f)
+        )
+        val rustMaps = RustMaps(
+            thumbnailUrl = "https://example.com/maps/abc/thumbnail.png",
+            imageIconUrl = "icon.png",
+            seed = 123,
+            size = 4000,
+            monumentCount = 12
+        )
         val details = Details(
             map = "Procedural Map",
             rustLastWipe = "2024-01-01T00:00:00Z",
@@ -59,7 +74,10 @@ class ServerExtensionsAdditionalTest {
             rustSettings = settings,
             rustMaps = rustMaps,
             rustWipes = wipes,
-            official = true
+            official = true,
+            rustWorldSeed = 123,
+            rustWorldSize = 4000,
+            rustFpsAvg = 25.5
         )
         val attributes = Attributes(
             id = "1",
@@ -94,6 +112,15 @@ class ServerExtensionsAdditionalTest {
         assertEquals("icon.png", info.mapImage)
         assertEquals(ServerStatus.ONLINE, info.status)
         assertEquals(WipeType.MAP, info.wipeType)
+        assertEquals(true, info.blueprints)
+        assertEquals(true, info.kits)
+        assertEquals(0.5f, info.decay)
+        assertEquals(1.0, info.upkeep)
+        assertEquals(3, info.rates)
+        assertEquals(123, info.seed)
+        assertEquals(4000, info.mapSize)
+        assertEquals(25.5, info.entityCount)
+        assertEquals(12, info.monuments)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- enrich `ServerInfo` with map-related fields
- pull map settings from stored Battlemetrics data
- document new fields in OpenAPI spec and README
- update tests to verify additional mapping

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6855fc14fd748321aeea59d135d35550