### PR TITLE
Extend server info fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ The response includes the requested page of servers and pagination fields:
 }
 ```
 
+Each server in the `servers` array exposes various attributes collected from
+Battlemetrics. Recent additions include `average_fps`, `pve`, `website`, and
+`is_premium` which indicate the average frames per second, PvE status, server
+homepage, and premium status respectively.
+
 ## Docker
 
 Build the application distribution and image:

--- a/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
@@ -91,6 +91,10 @@ fun BattlemetricsServerContent.toServerInfo(): ServerInfo =
         seed = attributes.details?.rustWorldSeed ?: attributes.details?.rustMaps?.seed,
         mapSize = attributes.details?.rustWorldSize ?: attributes.details?.rustMaps?.size,
         monuments = attributes.details?.rustMaps?.monumentCount,
+        averageFps = attributes.details?.rustFpsAvg?.toLong(),
+        pve = attributes.details?.pve,
+        website = attributes.details?.rustUrl,
+        isPremium = attributes.details?.rustPremium,
     )
 
 private fun calculateCycle(wipes: List<RustWipe>): Double? {

--- a/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
@@ -44,5 +44,11 @@ data class ServerInfo(
     val mapSize: Int? = null,
     @SerialName("entity_count")
     val entityCount: Double? = null,
-    val monuments: Int? = null
+    val monuments: Int? = null,
+    @SerialName("average_fps")
+    val averageFps: Long? = null,
+    val pve: Boolean? = null,
+    val website: String? = null,
+    @SerialName("is_premium")
+    val isPremium: Boolean? = null
 )

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -176,6 +176,14 @@ components:
           type: integer
         monuments:
           type: integer
+        average_fps:
+          type: integer
+        pve:
+          type: boolean
+        website:
+          type: string
+        is_premium:
+          type: boolean
     ServersResponse:
       type: object
       properties:

--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
@@ -75,9 +75,12 @@ class ServerExtensionsAdditionalTest {
             rustMaps = rustMaps,
             rustWipes = wipes,
             official = true,
+            pve = true,
             rustWorldSeed = 123L,
             rustWorldSize = 4000,
-            rustFpsAvg = 25.5
+            rustFpsAvg = 25.5,
+            rustUrl = "https://example.com",
+            rustPremium = true
         )
         val attributes = Attributes(
             id = "1",
@@ -120,6 +123,10 @@ class ServerExtensionsAdditionalTest {
         assertEquals(123L, info.seed)
         assertEquals(4000, info.mapSize)
         assertEquals(12, info.monuments)
+        assertEquals(25L, info.averageFps)
+        assertEquals(true, info.pve)
+        assertEquals("https://example.com", info.website)
+        assertEquals(true, info.isPremium)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove lastWipe from `ServerInfo`
- expose average FPS, PvE flag, website and premium status
- document new fields in README and Swagger spec
- verify new mappings in tests

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6856c0cbe6508321b20448c9b26eb2ed