### PR TITLE
Add mapUrl and headerImage to server info

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
@@ -75,6 +75,8 @@ fun BattlemetricsServerContent.toServerInfo(): ServerInfo =
         isOfficial = attributes.details?.official,
         serverIp = ipPort(attributes.ip ?: "", attributes.port?.toString() ?: ""),
         mapImage = attributes.details?.rustMaps?.imageIconUrl,
+        mapUrl = attributes.details?.rustMaps?.mapUrl,
+        headerImage = attributes.details?.rustHeaderimage,
         description = attributes.details?.rustDescription,
         wipeType = attributes.details?.rustWipes?.firstOrNull()?.type?.uppercase()?.let {
             try {

--- a/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
@@ -31,6 +31,10 @@ data class ServerInfo(
     val serverIp: String? = null,
     @SerialName("map_image")
     val mapImage: String? = null,
+    @SerialName("map_url")
+    val mapUrl: String? = null,
+    @SerialName("header_image")
+    val headerImage: String? = null,
     val description: String? = null,
     @SerialName("wipe_type")
     val wipeType: WipeType? = null,

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -154,6 +154,10 @@ components:
           type: string
         map_image:
           type: string
+        map_url:
+          type: string
+        header_image:
+          type: string
         description:
           type: string
         wipe_type:

--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
@@ -62,6 +62,7 @@ class ServerExtensionsAdditionalTest {
         val rustMaps = RustMaps(
             thumbnailUrl = "https://example.com/maps/abc/thumbnail.png",
             imageIconUrl = "icon.png",
+            mapUrl = "https://example.com/map",
             seed = 123L,
             size = 4000,
             monumentCount = 12
@@ -76,6 +77,7 @@ class ServerExtensionsAdditionalTest {
             rustWipes = wipes,
             official = true,
             pve = true,
+            rustHeaderimage = "header.png",
             rustWorldSeed = 123L,
             rustWorldSize = 4000,
             rustFpsAvg = 25.5,
@@ -113,6 +115,8 @@ class ServerExtensionsAdditionalTest {
         assertEquals(true, info.isOfficial)
         assertEquals("1.1.1.1:28015", info.serverIp)
         assertEquals("icon.png", info.mapImage)
+        assertEquals("https://example.com/map", info.mapUrl)
+        assertEquals("header.png", info.headerImage)
         assertEquals(ServerStatus.ONLINE, info.status)
         assertEquals(WipeType.MAP, info.wipeType)
         assertEquals(true, info.blueprints)


### PR DESCRIPTION
## Summary
- include `mapUrl` and `headerImage` fields in `ServerInfo`
- map new fields from Battlemetrics details
- document new fields in OpenAPI
- extend tests verifying the mapping

## Testing
- `./gradlew test --no-daemon --rerun-tasks`

------
https://chatgpt.com/codex/tasks/task_e_6856d12034f48321822f88ba0f9c0bf8