### PR TITLE
Remove logout endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ curl -X POST http://localhost:8080/auth/login \
   -d '{"username":"user","password":"password"}'
 ```
 
-Use the returned `accessToken` in the `Authorization` header (e.g. `Bearer <token>`) when calling `/servers` or `/filters/options`. The `refreshToken` can be sent to `/auth/refresh` to obtain new tokens or `/auth/logout` to invalidate it.
+Use the returned `accessToken` in the `Authorization` header (e.g. `Bearer <token>`) when calling `/servers` or `/filters/options`. The `refreshToken` can be sent to `/auth/refresh` to obtain new tokens.
 
 
 Example request:

--- a/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
@@ -43,11 +43,6 @@ class AuthEndpoint(private val service: AuthService) {
                         call.respond(HttpStatusCode.Unauthorized)
                     }
                 }
-                post("/logout") {
-                    val req = call.receive<RefreshRequest>()
-                    service.logout(req.refreshToken)
-                    call.respond(HttpStatusCode.OK)
-                }
             }
         }
     }

--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -44,10 +44,6 @@ class AuthService(
         return TokenPair(generateAccessToken(user.username), newRefresh)
     }
 
-    suspend fun logout(refreshToken: String) {
-        collection.updateOne(User::refreshToken eq refreshToken, setValue(User::refreshToken, null))
-    }
-
     private fun generateAccessToken(username: String): String {
         return JWT.create()
             .withAudience(jwtAudience)

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -169,18 +169,6 @@ paths:
         '401':
           description: Invalid refresh token
 
-  /auth/logout:
-    post:
-      summary: Logout user
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RefreshRequest'
-      responses:
-        '200':
-          description: Logged out
 components:
   schemas:
     ServerInfo:


### PR DESCRIPTION
## Summary
- drop `/logout` route and related code
- delete logout handler from AuthService
- remove `/auth/logout` path from OpenAPI docs
- update README instructions

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685715cbc3208321bd581de9849e95f6