### PR TITLE
Add anonymous user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ the following parameters can be used:
 - `mapSize` – map size
 - `monuments` – monument count
 
-Authentication is handled via JWT. First register and then use the tokens from `/auth/login`:
+Authentication is handled via JWT. Anonymous users can obtain a short-lived access token:
+
+```bash
+curl -X POST http://localhost:8080/auth/anonymous
+```
+
+Anonymous tokens cannot be refreshed. You can also register an account:
 
 ```bash
 curl -X POST http://localhost:8080/auth/register \
@@ -60,7 +66,7 @@ curl -X POST http://localhost:8080/auth/login \
   -d '{"username":"user","password":"password"}'
 ```
 
-Use the returned `accessToken` in the `Authorization` header (e.g. `Bearer <token>`) when calling `/servers` or `/filters/options`. The `refreshToken` can be sent to `/auth/refresh` to obtain new tokens or `/auth/logout` to invalidate it.
+Use the returned `accessToken` in the `Authorization` header (e.g. `Bearer <token>`) when calling `/servers` or `/filters/options`. When you register or log in, a `refreshToken` is also returned and can be sent to `/auth/refresh` to obtain new tokens or `/auth/logout` to invalidate it.
 
 
 Example request:

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/AccessToken.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/AccessToken.kt
@@ -1,0 +1,6 @@
+package pl.cuyer.thedome.domain.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AccessToken(val accessToken: String)

--- a/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
@@ -25,6 +25,9 @@ class AuthEndpoint(private val service: AuthService) {
                         call.respond(HttpStatusCode.Conflict)
                     }
                 }
+                post("/anonymous") {
+                    call.respond(service.registerAnonymous())
+                }
                 post("/login") {
                     val req = call.receive<LoginRequest>()
                     val tokens = service.login(req.username, req.password)

--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -7,6 +7,7 @@ import org.litote.kmongo.eq
 import org.litote.kmongo.setValue
 import pl.cuyer.thedome.domain.auth.User
 import pl.cuyer.thedome.domain.auth.TokenPair
+import pl.cuyer.thedome.domain.auth.AccessToken
 import java.util.Date
 import java.util.UUID
 import org.mindrot.jbcrypt.BCrypt
@@ -27,6 +28,13 @@ class AuthService(
         val user = User(username = username, passwordHash = hash, refreshToken = refresh)
         collection.insertOne(user)
         return TokenPair(generateAccessToken(username), refresh)
+    }
+
+    suspend fun registerAnonymous(): AccessToken {
+        val username = "anon-${UUID.randomUUID()}"
+        val user = User(username = username, passwordHash = "", refreshToken = null)
+        collection.insertOne(user)
+        return AccessToken(generateAccessToken(username))
     }
 
     suspend fun login(username: String, password: String): TokenPair? {

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -112,6 +112,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/FiltersOptions'
 
+  /auth/anonymous:
+    post:
+      summary: Obtain anonymous access token
+      responses:
+        '200':
+          description: Access token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessToken'
+
   /auth/register:
     post:
       summary: Register user
@@ -327,4 +338,9 @@ components:
         accessToken:
           type: string
         refreshToken:
+          type: string
+    AccessToken:
+      type: object
+      properties:
+        accessToken:
           type: string

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
@@ -1,0 +1,25 @@
+package pl.cuyer.thedome.services
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.litote.kmongo.coroutine.CoroutineCollection
+import pl.cuyer.thedome.domain.auth.User
+import com.mongodb.client.model.InsertOneOptions
+
+class AuthServiceTest {
+    @Test
+    fun `registerAnonymous stores user`() = runBlocking {
+        val collection = mockk<CoroutineCollection<User>>()
+        coEvery { collection.insertOne(any(), any<InsertOneOptions>()) } returns mockk()
+        val service = AuthService(collection, "secret", "issuer", "audience")
+
+        val result = service.registerAnonymous()
+
+        assertTrue(result.accessToken.isNotEmpty())
+        coVerify { collection.insertOne(match { it.username.startsWith("anon-") && it.refreshToken == null }, any<InsertOneOptions>()) }
+    }
+}


### PR DESCRIPTION
## Summary
- allow creating anonymous users via AuthService
- expose new `/auth/anonymous` endpoint
- document anonymous user creation in README
- test anonymous registration

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6857109ff31c83218f74fe33c5df8de8