### PR TITLE
Remove JWT secret fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,7 @@ WORKDIR /app
 # Copy built distribution from build stage
 COPY --from=build /app/build/install/thedome /app
 
-ENV JWT_SECRET=secret \
-    JWT_AUDIENCE=thedomeAudience \
+ENV JWT_AUDIENCE=thedomeAudience \
     JWT_ISSUER=thedomeIssuer \
     JWT_REALM=thedomeRealm
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Environment variables:
 - `FETCH_CRON` – cron expression for server fetch schedule (defaults to every 10 minutes; uses seconds as the first field)
 - `API_KEY` – optional RustMaps API key
 - `PORT` – overrides the default port if implemented
-- `JWT_SECRET` – HMAC secret for signing tokens (default `secret`)
+- `JWT_SECRET` – HMAC secret for signing tokens (**required**; the application fails if missing)
 - `JWT_AUDIENCE` – JWT audience (default `thedomeAudience`)
 - `JWT_ISSUER` – JWT issuer (default `thedomeIssuer`)
 - `JWT_REALM` – authentication realm (default `thedomeRealm`)
@@ -111,10 +111,10 @@ Build the application distribution and image:
 docker build -t thedome .
 ```
 
-Run the container exposing port 8080:
+Run the container exposing port 8080 (set `JWT_SECRET` to start):
 
 ```bash
-docker run -p 8080:8080 thedome
+docker run -e JWT_SECRET=supersecret -p 8080:8080 thedome
 ```
 
 ## Docker Compose

--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -86,7 +86,7 @@ fun Application.module() {
     val jwtAudience = System.getenv("JWT_AUDIENCE") ?: "thedomeAudience"
     val jwtIssuer = System.getenv("JWT_ISSUER") ?: "thedomeIssuer"
     val jwtRealm = System.getenv("JWT_REALM") ?: "thedomeRealm"
-    val jwtSecret = System.getenv("JWT_SECRET") ?: "secret"
+    val jwtSecret = System.getenv("JWT_SECRET") ?: error("JWT_SECRET not set")
 
     install(Authentication) {
         jwt("auth-jwt") {


### PR DESCRIPTION
## Summary
- require `JWT_SECRET` in Application startup
- drop default `JWT_SECRET` from Docker image
- document the required `JWT_SECRET` env var

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68578adfd0c08321a63748e12caeefb7