### PR TITLE
Configure CORS using env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Environment variables:
 - `JWT_AUDIENCE` – JWT audience (default `thedomeAudience`)
 - `JWT_ISSUER` – JWT issuer (default `thedomeIssuer`)
 - `JWT_REALM` – authentication realm (default `thedomeRealm`)
+- `ALLOWED_ORIGINS` – comma-separated list of allowed CORS origins (useful in production)
 - Unhandled exceptions are logged via Ktor's `StatusPages` plugin
 
 Query servers with optional filtering. Alongside pagination (`page` and `size`),

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ services:
       # API_KEY: ""  # Optional, set if you have a RustMaps API key
       # PORT: 8080  # Override if you want a different port
       # JWT_SECRET: secret
+      # ALLOWED_ORIGINS: "https://example.com,https://example2.com"  # Set allowed CORS origins in production
     depends_on:
       - mongo
     networks:

--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -78,8 +78,20 @@ fun Application.module() {
         }
     }
 
+    val allowedOriginsEnv = System.getenv("ALLOWED_ORIGINS")
     install(CORS) {
-        anyHost()
+        if (allowedOriginsEnv.isNullOrBlank()) {
+            anyHost()
+        } else {
+            allowedOriginsEnv.split(",").map { it.trim() }.filter { it.isNotEmpty() }.forEach { origin ->
+                val uri = try { java.net.URI(origin) } catch (_: Exception) { null }
+                if (uri != null && uri.host != null) {
+                    allowHost(uri.host, schemes = listOfNotNull(uri.scheme))
+                } else {
+                    allowHost(origin)
+                }
+            }
+        }
         allowHeader(HttpHeaders.ContentType)
     }
 


### PR DESCRIPTION
## Summary
- configure allowed CORS origins from the `ALLOWED_ORIGINS` env var
- document the new variable in README
- add example in compose file

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68578af55df883219c0fb66bb1097e09