### PR TITLE
Add unique index for usernames

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -53,7 +53,11 @@ val appModule = module {
     }
 
     single<CoroutineCollection<User>> {
-        get<CoroutineDatabase>().getCollection<User>("users")
+        val collection = get<CoroutineDatabase>().getCollection<User>("users")
+        runBlocking {
+            collection.ensureUniqueIndex(User::username)
+        }
+        collection
     }
 
     single { ServerFetchService(get(), get()) }


### PR DESCRIPTION
## Summary
- ensure user collection has a unique index on `username`

## Testing
- `./gradlew test --no-daemon`
- `./gradlew assemble --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68578afea6248321afdf7fde17018cca