### PR TITLE
Add .dockerignore for leaner Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Ignore version control directory
+.git
+
+# Gradle build outputs and caches
+build/
+.gradle/
+
+# Test sources are not needed in the image
+src/test/
+
+# Continuous integration configuration and editor files
+.github/
+.idea/
+


### PR DESCRIPTION
## Summary
- add `.dockerignore` to exclude git data, Gradle build output and test sources

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68578ec460e48321831ab714c092407a