### PR TITLE
Fix trailing whitespace in AuthService

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -56,7 +56,7 @@ class AuthService(
         collection.updateOne(User::username eq newUsername, setValue(User::refreshToken, hashedRefresh))
         return TokenPair(generateAccessToken(newUsername), refresh)
     }
-    
+
     suspend fun login(username: String, password: String): TokenPair? {
         val user = collection.findOne(User::username eq username) ?: return null
         if (!BCrypt.checkpw(password, user.passwordHash)) return null


### PR DESCRIPTION
## Summary
- remove trailing spaces from line 59 of AuthService

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68578f0f2b40832198abf6cd0ad9ddbf