### PR TITLE
Pin MongoDB version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You can run the project and its MongoDB dependency using Docker Compose. The pro
 ### Requirements
 - Docker and Docker Compose installed
 - The application is built using Eclipse Temurin JDK 21 (Alpine base image)
-- MongoDB is included as a service in the compose file
+- MongoDB 7 is included as a service in the compose file (image `mongo:7`) to avoid unexpected upgrades
 
 ### Environment Variables
 - `MONGODB_URI` – MongoDB connection string (defaults to `mongodb://mongo:27017/thedome` for the container)
@@ -159,7 +159,7 @@ MongoDB data is persisted in a Docker volume named `mongo-data`.
 
 ## Running with Docker
 
-You can run the backend and MongoDB together using Docker Compose. The setup uses Eclipse Temurin JDK 21 (Alpine) for the application and the latest MongoDB image. The application container is named `kotlin-thedome` and MongoDB is named `mongo`.
+You can run the backend and MongoDB together using Docker Compose. The setup uses Eclipse Temurin JDK 21 (Alpine) for the application and the MongoDB 7 image. The application container is named `kotlin-thedome` and MongoDB is named `mongo`.
 
 - The application exposes port `8080` (mapped to host `8080`).
 - MongoDB exposes port `27017` (mapped to host `27017`).

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
     # env_file: ./.env  # Uncomment if .env file exists
 
   mongo:
-    image: mongo:latest
+    image: mongo:7
     container_name: mongo
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- pin MongoDB image to `mongo:7` in Docker compose config
- document the version in the README so upgrades don't break

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68578f78c348832194148d0c4b13d463