### PR TITLE
Implement cleanup in AnonymousRateLimit

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/plugins/AnonymousRateLimit.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/plugins/AnonymousRateLimit.kt
@@ -6,18 +6,41 @@ import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.response.*
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.*
 
 class AnonymousRateLimitConfig {
     var requestsPerMinute: Int = 60
+    var cleanupIntervalMillis: Long = 60_000
+    var requestTtlMillis: Long = 60_000
 }
 
-private class RateInfo(var count: Int, var startMillis: Long)
+internal class RateInfo(var count: Int, var startMillis: Long)
+
+internal fun launchCleanupJob(
+    scope: CoroutineScope,
+    requests: ConcurrentHashMap<String, RateInfo>,
+    ttl: Long,
+    interval: Long
+): Job = scope.launch {
+    while (isActive) {
+        delay(interval)
+        val now = System.currentTimeMillis()
+        requests.entries.removeIf { now - it.value.startMillis >= ttl }
+    }
+}
 
 val AnonymousRateLimit = createApplicationPlugin(
     name = "AnonymousRateLimit",
     createConfiguration = ::AnonymousRateLimitConfig
 ) {
     val requests = ConcurrentHashMap<String, RateInfo>()
+    val cleanupJob = launchCleanupJob(
+        application,
+        requests,
+        pluginConfig.requestTtlMillis,
+        pluginConfig.cleanupIntervalMillis
+    )
+    environment.monitor.subscribe(ApplicationStopped) { cleanupJob.cancel() }
 
     onCall { call ->
         val principal = call.principal<JWTPrincipal>() ?: return@onCall
@@ -25,7 +48,7 @@ val AnonymousRateLimit = createApplicationPlugin(
         if (!username.startsWith("anon-")) return@onCall
         val now = System.currentTimeMillis()
         val info = requests.compute(username) { _, existing ->
-            if (existing == null || now - existing.startMillis >= 60_000) {
+            if (existing == null || now - existing.startMillis >= pluginConfig.requestTtlMillis) {
                 RateInfo(1, now)
             } else {
                 existing.count += 1

--- a/src/test/kotlin/pl/cuyer/thedome/plugins/AnonymousRateLimitTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/plugins/AnonymousRateLimitTest.kt
@@ -1,0 +1,19 @@
+package pl.cuyer.thedome.plugins
+
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import java.util.concurrent.ConcurrentHashMap
+
+class AnonymousRateLimitTest {
+    @Test
+    fun `cleanup removes expired entries`() = runBlocking {
+        val requests = ConcurrentHashMap<String, RateInfo>()
+        val job = launchCleanupJob(this, requests, ttl = 50, interval = 10)
+        requests["anon-1"] = RateInfo(1, System.currentTimeMillis() - 100)
+        kotlinx.coroutines.delay(60)
+        job.cancel()
+        job.join()
+        assertTrue(requests.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable cleanup job for anonymous rate limiting
- verify expiration behaviour with unit test

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68578f7c2978832185efeeb3931bb24d