### PR TITLE
Configure CallLogging plugin globally

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -39,6 +39,7 @@ import org.koin.ktor.ext.inject
 import org.koin.logger.slf4jLogger
 import pl.cuyer.thedome.di.appModule
 import pl.cuyer.thedome.AppConfig
+import pl.cuyer.thedome.utils.logException
 import pl.cuyer.thedome.domain.ErrorResponse
 import pl.cuyer.thedome.exceptions.UserAlreadyExistsException
 import pl.cuyer.thedome.exceptions.InvalidCredentialsException
@@ -51,7 +52,6 @@ import com.auth0.jwt.algorithms.Algorithm
 
 private const val API_VERSION = "1.0.0"
 private val logger = LoggerFactory.getLogger("pl.cuyer.thedome.Application")
-
 
 fun main() {
     val port = System.getenv("PORT")?.toIntOrNull() ?: 8080
@@ -71,24 +71,31 @@ fun Application.module() {
     install(Resources)
     install(StatusPages) {
         exception<UserAlreadyExistsException> { call, cause ->
+            logException(call, cause)
             call.respond(HttpStatusCode.Conflict, ErrorResponse(cause.message ?: "Conflict"))
         }
         exception<InvalidCredentialsException> { call, cause ->
+            logException(call, cause)
             call.respond(HttpStatusCode.Unauthorized, ErrorResponse(cause.message ?: "Unauthorized"))
         }
         exception<InvalidRefreshTokenException> { call, cause ->
+            logException(call, cause)
             call.respond(HttpStatusCode.Unauthorized, ErrorResponse(cause.message ?: "Unauthorized"))
         }
         exception<AnonymousUpgradeException> { call, cause ->
+            logException(call, cause)
             call.respond(HttpStatusCode.Conflict, ErrorResponse(cause.message ?: "Conflict"))
         }
         exception<FiltersOptionsException> { call, cause ->
+            logException(call, cause)
             call.respond(HttpStatusCode.InternalServerError, ErrorResponse(cause.message ?: "Internal server error"))
         }
         exception<ServersQueryException> { call, cause ->
+            logException(call, cause)
             call.respond(HttpStatusCode.InternalServerError, ErrorResponse(cause.message ?: "Internal server error"))
         }
         exception<Throwable> { call, cause ->
+            logException(call, cause)
             call.respond(HttpStatusCode.InternalServerError, ErrorResponse(cause.message ?: "Internal server error"))
         }
         status(HttpStatusCode.NotFound) { call, status ->
@@ -96,7 +103,6 @@ fun Application.module() {
         }
     }
     install(CallLogging) {
-        filter { call -> call.request.path().startsWith("/servers") }
         format { call ->
             val status = call.response.status()
             val httpMethod = call.request.httpMethod.value

--- a/src/main/kotlin/pl/cuyer/thedome/utils/Logging.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/utils/Logging.kt
@@ -1,0 +1,13 @@
+package pl.cuyer.thedome.utils
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.*
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("pl.cuyer.thedome.Application")
+
+fun logException(call: ApplicationCall, cause: Throwable) {
+    val method = call.request.httpMethod.value
+    val uri = call.request.uri
+    logger.error("Exception during $method $uri: ${'$'}{cause.message}", cause)
+}


### PR DESCRIPTION
## Summary
- remove CallLogging filter so logging is handled for all requests
- log the request path and stacktrace for all handled exceptions
- move `logException` helper to a utils file

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6857b58316248321bf758853652ebee3