### PR TITLE
Add username to anonymous token

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/AccessToken.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/AccessToken.kt
@@ -3,4 +3,4 @@ package pl.cuyer.thedome.domain.auth
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class AccessToken(val accessToken: String)
+data class AccessToken(val accessToken: String, val username: String)

--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -47,7 +47,7 @@ class AuthService(
         val user = User(username = username, passwordHash = "", refreshToken = null)
         collection.insertOne(user)
         logger.info("Anonymous user $username registered")
-        return AccessToken(generateAccessToken(username))
+        return AccessToken(generateAccessToken(username), username)
     }
 
     suspend fun upgradeAnonymous(currentUsername: String, newUsername: String, password: String): TokenPair? {

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -117,7 +117,7 @@ paths:
       summary: Obtain anonymous access token
       responses:
         '200':
-          description: Access token
+          description: Access token and username
           content:
             application/json:
               schema:
@@ -351,6 +351,8 @@ components:
       type: object
       properties:
         accessToken:
+          type: string
+        username:
           type: string
     UpgradeRequest:
       type: object

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
@@ -30,6 +30,7 @@ class AuthServiceTest {
         val result = service.registerAnonymous()
 
         assertTrue(result.accessToken.isNotEmpty())
+        assertTrue(result.username.startsWith("anon-"))
         coVerify { collection.insertOne(match { it.username.startsWith("anon-") && it.refreshToken == null }, any<InsertOneOptions>()) }
     }
     @Test


### PR DESCRIPTION
## Summary
- include username in `AccessToken`
- return username from `/auth/anonymous`
- document this in OpenAPI
- test anonymous registration returns username

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6857d351f8b083219e9a680c8e2bb1b4