### PR TITLE
Extend auth endpoints with email and login flexibility

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -57,6 +57,7 @@ fun appModule(config: AppConfig) = module {
         val collection = get<CoroutineDatabase>().getCollection<User>("users")
         runBlocking {
             collection.ensureUniqueIndex(User::username)
+            collection.ensureUniqueIndex(User::email)
         }
         collection
     }

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/RegisterRequest.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/RegisterRequest.kt
@@ -3,4 +3,8 @@ package pl.cuyer.thedome.domain.auth
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class RegisterRequest(val username: String, val password: String)
+data class RegisterRequest(
+    val username: String,
+    val password: String,
+    val email: String
+)

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/TokenPair.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/TokenPair.kt
@@ -3,4 +3,9 @@ package pl.cuyer.thedome.domain.auth
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TokenPair(val accessToken: String, val refreshToken: String)
+data class TokenPair(
+    val accessToken: String,
+    val refreshToken: String,
+    val username: String,
+    val email: String?
+)

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/User.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/User.kt
@@ -11,6 +11,7 @@ data class User(
     @Serializable(with = ObjectIdSerializer::class)
     val id: ObjectId? = null,
     val username: String,
+    val email: String? = null,
     val passwordHash: String,
     val refreshToken: String? = null
 )

--- a/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
@@ -26,7 +26,7 @@ class AuthEndpoint(private val service: AuthService) {
             route("/auth") {
                 post("/register") {
                     val req = call.receive<RegisterRequest>()
-                    val tokens = service.register(req.username, req.password)
+                    val tokens = service.register(req.username, req.email, req.password)
                         ?: throw UserAlreadyExistsException()
                     call.respond(tokens)
                 }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -326,6 +326,8 @@ components:
       properties:
         username:
           type: string
+        email:
+          type: string
         password:
           type: string
     LoginRequest:
@@ -346,6 +348,10 @@ components:
         accessToken:
           type: string
         refreshToken:
+          type: string
+        username:
+          type: string
+        email:
           type: string
     AccessToken:
       type: object


### PR DESCRIPTION
## Summary
- include email in `RegisterRequest`, `User`, `TokenPair`
- handle email lookups and return username/email in `AuthService`
- support email uniqueness via Koin module
- update auth routes and OpenAPI docs
- adjust tests for new auth behaviour

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685815b85b808321ac2dcf36be0b6ced