### PR TITLE
Filter outdated battlemetrics servers

### DIFF
--- a/src/test/kotlin/pl/cuyer/thedome/services/ServerFetchServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/ServerFetchServiceTest.kt
@@ -13,6 +13,9 @@ import kotlinx.serialization.json.Json
 import io.mockk.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.DeleteOptions
 import com.mongodb.client.model.ReplaceOneModel
@@ -59,12 +62,13 @@ class ServerFetchServiceTest {
 
     @Test
     fun `fetchServers only updates newer data`() = runBlocking {
+        val year = Clock.System.now().toLocalDateTime(TimeZone.UTC).year
         val new1 = BattlemetricsServerContent(
-            attributes = Attributes(id = "a1", updatedAt = "2024-01-02T00:00:00Z"),
+            attributes = Attributes(id = "a1", updatedAt = "${year}-01-02T00:00:00Z"),
             id = "1"
         )
         val new2 = BattlemetricsServerContent(
-            attributes = Attributes(id = "a2", updatedAt = "2024-01-01T00:00:00Z"),
+            attributes = Attributes(id = "a2", updatedAt = "${year}-01-01T00:00:00Z"),
             id = "2"
         )
         val page = BattlemetricsPage(data = listOf(new1, new2), links = Links(null))
@@ -82,14 +86,53 @@ class ServerFetchServiceTest {
         val findPub = mockk<CoroutineFindPublisher<BattlemetricsServerContent>>()
         every { collection.find(any<Bson>()) } returns findPub
         val existing1 = BattlemetricsServerContent(
-            attributes = Attributes(id = "a1", updatedAt = "2024-01-01T00:00:00Z"),
+            attributes = Attributes(id = "a1", updatedAt = "${year}-01-01T00:00:00Z"),
             id = "1"
         )
         val existing2 = BattlemetricsServerContent(
-            attributes = Attributes(id = "a2", updatedAt = "2024-01-02T00:00:00Z"),
+            attributes = Attributes(id = "a2", updatedAt = "${year}-01-02T00:00:00Z"),
             id = "2"
         )
         coEvery { findPub.toList() } returns listOf(existing1, existing2)
+
+        val slotOps = slot<List<ReplaceOneModel<BattlemetricsServerContent>>>()
+        coEvery { collection.bulkWrite(capture(slotOps), any<BulkWriteOptions>()) } returns mockk()
+        coEvery { collection.deleteMany(any<Bson>(), any<DeleteOptions>()) } returns mockk()
+
+        val service = ServerFetchService(client, collection, "")
+        service.fetchServers()
+
+        assertEquals(1, slotOps.captured.size)
+        assertEquals("1", slotOps.captured.first().replacement.id)
+    }
+
+    @Test
+    fun `fetchServers filters outdated servers`() = runBlocking {
+        val year = Clock.System.now().toLocalDateTime(TimeZone.UTC).year
+        val oldYear = year - 1
+        val recent = BattlemetricsServerContent(
+            attributes = Attributes(id = "a1", updatedAt = "${year}-01-01T00:00:00Z"),
+            id = "1"
+        )
+        val outdated = BattlemetricsServerContent(
+            attributes = Attributes(id = "a2", updatedAt = "${oldYear}-12-31T23:59:59Z"),
+            id = "2"
+        )
+        val page = BattlemetricsPage(data = listOf(recent, outdated), links = Links(null))
+
+        val engine = MockEngine {
+            respond(
+                content = ByteReadChannel(json.encodeToString(page)),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
+
+        val collection = mockk<CoroutineCollection<BattlemetricsServerContent>>()
+        val findPub = mockk<CoroutineFindPublisher<BattlemetricsServerContent>>()
+        every { collection.find(any<Bson>()) } returns findPub
+        coEvery { findPub.toList() } returns emptyList()
 
         val slotOps = slot<List<ReplaceOneModel<BattlemetricsServerContent>>>()
         coEvery { collection.bulkWrite(capture(slotOps), any<BulkWriteOptions>()) } returns mockk()


### PR DESCRIPTION
## Summary
- ignore Battlemetrics servers whose last update is before the current year
- adjust `ServerFetchServiceTest` to use dynamic years
- test that old servers are filtered out during fetch

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6859729472488321b78375bf26f1f441