### PR TITLE
Use single MongoDB client

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -1,6 +1,7 @@
 package pl.cuyer.thedome
 
 import com.mongodb.kotlin.client.coroutine.MongoClient
+import com.mongodb.reactivestreams.client.MongoClient as ReactiveMongoClient
 import dev.inmo.krontab.builder.SchedulerBuilder
 import dev.inmo.krontab.builder.TimeBuilder
 import io.github.flaxoos.ktor.server.plugins.taskscheduling.TaskScheduling
@@ -175,8 +176,8 @@ fun Application.module() {
     }
 
     val fetchService by inject<ServerFetchService>()
-
-    val schedulerClient = MongoClient.create(config.mongoUri)
+    val reactiveMongoClient by inject<ReactiveMongoClient>()
+    val schedulerClient = MongoClient(reactiveMongoClient)
     logger.info("Scheduling fetch task with cron expression '${config.fetchCron}'")
 
     install(TaskScheduling) {

--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -11,6 +11,7 @@ import org.litote.kmongo.coroutine.CoroutineCollection
 import org.litote.kmongo.coroutine.CoroutineDatabase
 import org.litote.kmongo.reactivestreams.KMongo
 import org.litote.kmongo.coroutine.coroutine
+import com.mongodb.reactivestreams.client.MongoClient as ReactiveMongoClient
 import com.mongodb.client.model.IndexOptions
 import org.bson.Document
 import org.koin.dsl.module
@@ -32,9 +33,11 @@ fun appModule(config: AppConfig) = module {
         }
     }
 
-    single<CoroutineClient> {
-        KMongo.createClient(config.mongoUri).coroutine
+    single<ReactiveMongoClient> {
+        KMongo.createClient(config.mongoUri)
     }
+
+    single<CoroutineClient> { get<ReactiveMongoClient>().coroutine }
 
     single<CoroutineDatabase> { get<CoroutineClient>().getDatabase("thedome") }
 


### PR DESCRIPTION
## Summary
- instantiate one reactive Mongo client in DI
- reuse that instance for scheduled tasks

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_685970b33ff4832184d5b8789c5b8ea2