### PR TITLE
Add cleanup scheduler for stale servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Environment variables:
 
 - `MONGODB_URI` – MongoDB connection string
 - `FETCH_CRON` – cron expression for server fetch schedule (defaults to every 10 minutes; uses seconds as the first field)
+- `CLEANUP_CRON` – cron expression for removing servers not updated for two months (defaults to daily at midnight)
 - `API_KEY` – optional RustMaps API key
 - `PORT` – overrides the default port if implemented
 - Unhandled exceptions are logged via Ktor's `StatusPages` plugin
@@ -93,6 +94,7 @@ You can run the project and its MongoDB dependency using Docker Compose. The pro
 ### Environment Variables
 - `MONGODB_URI` – MongoDB connection string (defaults to `mongodb://mongo:27017/thedome` for the container)
 - `FETCH_CRON` – cron expression for server fetch schedule (optional)
+- `CLEANUP_CRON` – cron expression for removing servers not updated for two months (optional)
 - `API_KEY` – optional RustMaps API key (optional)
 - `PORT` – application port (defaults to `8080`)
 
@@ -128,7 +130,7 @@ You can run the backend and MongoDB together using Docker Compose. The setup use
 - MongoDB exposes port `27017` (mapped to host `27017`).
 - MongoDB data is persisted in the `mongo-data` Docker volume.
 - The default MongoDB URI inside the container is `mongodb://mongo:27017/thedome`.
-- You can override environment variables such as `MONGODB_URI`, `FETCH_CRON`, `API_KEY`, and `PORT` in the `docker-compose.yml` or via an `.env` file.
+ - You can override environment variables such as `MONGODB_URI`, `FETCH_CRON`, `CLEANUP_CRON`, `API_KEY`, and `PORT` in the `docker-compose.yml` or via an `.env` file.
 
 To start everything:
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
       # Default MongoDB URI for the app to connect to the mongo service
       MONGODB_URI: mongodb://mongo:27017/thedome
       # FETCH_CRON: "*/10 * * * * *"  # Uncomment and set as needed
+      # CLEANUP_CRON: "0 0 * * *"  # Uncomment to schedule cleanup of old servers
       # API_KEY: ""  # Optional, set if you have a RustMaps API key
       # PORT: 8080  # Override if you want a different port
     depends_on:

--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -81,8 +81,10 @@ fun Application.module() {
     val fetchService by inject<ServerFetchService>()
 
     val fetchCron = System.getenv("FETCH_CRON") ?: "0 */10 * * *"
+    val cleanupCron = System.getenv("CLEANUP_CRON") ?: "0 0 * * *"
     val schedulerClient = MongoClient.create(mongoUri)
     logger.info("Scheduling fetch task with cron expression '$fetchCron'")
+    logger.info("Scheduling cleanup task with cron expression '$cleanupCron'")
 
     install(TaskScheduling) {
         mongoDb {
@@ -93,6 +95,11 @@ fun Application.module() {
             name = "fetch-servers"
             kronSchedule = { applyCron(fetchCron) }
             task = { fetchService.fetchServers() }
+        }
+        task {
+            name = "cleanup-servers"
+            kronSchedule = { applyCron(cleanupCron) }
+            task = { fetchService.cleanupServers() }
         }
     }
 

--- a/src/main/kotlin/pl/cuyer/thedome/services/ServerFetchService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/ServerFetchService.kt
@@ -7,12 +7,14 @@ import io.ktor.client.request.*
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.datetime.Clock
 import org.litote.kmongo.coroutine.CoroutineCollection
 import org.slf4j.LoggerFactory
 import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsPage
 import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
 import pl.cuyer.thedome.domain.battlemetrics.extractMapId
 import pl.cuyer.thedome.domain.battlemetrics.fetchMapIcon
+import kotlin.time.Duration.Companion.days
 
 class ServerFetchService(
     private val client: HttpClient,
@@ -70,13 +72,27 @@ class ServerFetchService(
             }
             collection.bulkWrite(replaceOperations, BulkWriteOptions().ordered(false))
 
-            val idsToKeep = servers.map { it.id }
-            collection.deleteMany(Filters.nin("id", idsToKeep))
-
-            logger.info("Upserted ${servers.size} servers and removed stale entries.")
+            logger.info("Upserted ${servers.size} servers.")
 
         } catch (e: Exception) {
             logger.error("Failed to fetch or update servers: ${e.message}", e)
+        }
+    }
+
+    suspend fun cleanupServers() {
+        val cutoff = Clock.System.now() - 60.days
+        val cutoffIso = cutoff.toString()
+        logger.info("Removing servers not updated since $cutoffIso")
+
+        try {
+            val filter = Filters.or(
+                Filters.lt("attributes.updatedAt", cutoffIso),
+                Filters.exists("attributes.updatedAt", false)
+            )
+            val result = collection.deleteMany(filter)
+            logger.info("Removed ${result.deletedCount} stale servers.")
+        } catch (e: Exception) {
+            logger.error("Failed to clean up servers: ${e.message}", e)
         }
     }
 }

--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
@@ -62,7 +62,7 @@ class ServerExtensionsAdditionalTest {
         val rustMaps = RustMaps(
             thumbnailUrl = "https://example.com/maps/abc/thumbnail.png",
             imageIconUrl = "icon.png",
-            mapUrl = "https://example.com/map",
+            url = "https://example.com/map",
             seed = 123L,
             size = 4000,
             monumentCount = 12

--- a/src/test/kotlin/pl/cuyer/thedome/services/ServerFetchServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/ServerFetchServiceTest.kt
@@ -2,8 +2,8 @@ package pl.cuyer.thedome.services
 
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
+import io.ktor.client.engine.mock.respondOk
 import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.utils.io.*
@@ -14,8 +14,8 @@ import io.mockk.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import com.mongodb.client.model.BulkWriteOptions
-import com.mongodb.client.model.DeleteOptions
 import com.mongodb.client.model.ReplaceOneModel
+import com.mongodb.client.model.DeleteOptions
 import org.bson.conversions.Bson
 import org.litote.kmongo.coroutine.CoroutineCollection
 import pl.cuyer.thedome.domain.battlemetrics.*
@@ -24,7 +24,7 @@ class ServerFetchServiceTest {
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun `fetchServers upserts and removes`() = runBlocking {
+    fun `fetchServers upserts`() = runBlocking {
         val server1 = BattlemetricsServerContent(attributes = Attributes(id = "a1"), id = "1")
         val server2 = BattlemetricsServerContent(attributes = Attributes(id = "a2"), id = "2")
         val page = BattlemetricsPage(data = listOf(server1, server2), links = Links(null))
@@ -40,9 +40,7 @@ class ServerFetchServiceTest {
 
         val collection = mockk<CoroutineCollection<BattlemetricsServerContent>>()
         val slotOps = slot<List<ReplaceOneModel<BattlemetricsServerContent>>>()
-        val slotFilter = slot<Bson>()
         coEvery { collection.bulkWrite(capture(slotOps), any<BulkWriteOptions>()) } returns mockk()
-        coEvery { collection.deleteMany(capture(slotFilter)) } returns mockk()
 
         val service = ServerFetchService(client, collection)
         service.fetchServers()
@@ -50,6 +48,19 @@ class ServerFetchServiceTest {
         assertEquals(2, slotOps.captured.size)
         val ids = slotOps.captured.map { it.replacement.id }.toSet()
         assertEquals(setOf("1", "2"), ids)
+        coVerify(exactly = 0) { collection.deleteMany(any<Bson>()) }
+    }
+
+    @Test
+    fun `cleanupServers removes stale entries`() = runBlocking {
+        val client = HttpClient(MockEngine { respondOk() })
+
+        val collection = mockk<CoroutineCollection<BattlemetricsServerContent>>()
+        coEvery { collection.deleteMany(any<Bson>(), any<DeleteOptions>()) } returns mockk()
+
+        val service = ServerFetchService(client, collection)
+        service.cleanupServers()
+
         coVerify(exactly = 1) { collection.deleteMany(any<Bson>(), any<DeleteOptions>()) }
     }
 }


### PR DESCRIPTION
## Summary
- stop removing stale servers during fetch
- add a new `cleanupServers` job scheduled with `CLEANUP_CRON`
- log cron expressions when starting
- document the cleanup cron variable and expose it in compose
- remove servers that haven't been updated in 2 months

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6859d1e700e083219f0f07304a4bd9c6