### PR TITLE
Implement server cleanup job

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Values can also be specified in `src/main/resources/application.conf` under the 
 
 - `MONGODB_URI` – MongoDB connection string
 - `FETCH_CRON` – cron expression for server fetch schedule (defaults to every 10 minutes; uses seconds as the first field)
+- `CLEANUP_CRON` – cron expression for removing outdated servers (defaults to daily at midnight)
 - `API_KEY` – optional RustMaps API key
 - `PORT` – overrides the default port if implemented
 - `JWT_SECRET` – HMAC secret for signing tokens (**required**; the application fails if missing)
@@ -147,6 +148,7 @@ You can run the project and its MongoDB dependency using Docker Compose. The pro
 ### Environment Variables
 - `MONGODB_URI` – MongoDB connection string (defaults to `mongodb://mongo:27017/thedome` for the container)
 - `FETCH_CRON` – cron expression for server fetch schedule (optional)
+- `CLEANUP_CRON` – cron expression for server cleanup schedule (optional)
 - `API_KEY` – optional RustMaps API key (optional)
 - `PORT` – application port (defaults to `8080`)
 
@@ -182,7 +184,7 @@ You can run the backend and MongoDB together using Docker Compose. The setup use
 - MongoDB exposes port `27017` (mapped to host `27017`).
 - MongoDB data is persisted in the `mongo-data` Docker volume.
 - The default MongoDB URI inside the container is `mongodb://mongo:27017/thedome`.
-- You can override environment variables such as `MONGODB_URI`, `FETCH_CRON`, `API_KEY`, and `PORT` in the `compose.yaml` or via an `.env` file.
+- You can override environment variables such as `MONGODB_URI`, `FETCH_CRON`, `CLEANUP_CRON`, `API_KEY`, and `PORT` in the `compose.yaml` or via an `.env` file.
 
 To start everything:
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
       # Default MongoDB URI for the app to connect to the mongo service
       MONGODB_URI: mongodb://mongo:27017/thedome
       # FETCH_CRON: "*/10 * * * * *"  # Uncomment and set as needed
+      # CLEANUP_CRON: "0 0 * * *"  # Uncomment to set cleanup schedule
       # API_KEY: ""  # Optional, set if you have a RustMaps API key
       # PORT: 8080  # Override if you want a different port
       # JWT_SECRET: secret

--- a/src/main/kotlin/pl/cuyer/thedome/AppConfig.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/AppConfig.kt
@@ -9,6 +9,7 @@ data class AppConfig(
     val jwtRealm: String,
     val jwtSecret: String,
     val fetchCron: String,
+    val cleanupCron: String,
     val mongoUri: String,
     val apiKey: String,
     val anonRateLimit: Int,
@@ -25,6 +26,7 @@ data class AppConfig(
             val jwtIssuer = jwtSection.propertyOrNull("issuer")?.getString() ?: "thedomeIssuer"
             val jwtRealm = jwtSection.propertyOrNull("realm")?.getString() ?: "thedomeRealm"
             val fetchCron = section.propertyOrNull("fetchCron")?.getString() ?: "0 */10 * * *"
+            val cleanupCron = section.propertyOrNull("cleanupCron")?.getString() ?: "0 0 * * *"
             val mongoUri = section.propertyOrNull("mongoUri")?.getString() ?: "mongodb://localhost:27017"
             val apiKey = section.propertyOrNull("apiKey")?.getString() ?: ""
             val anonRateLimit = section.propertyOrNull("anonRateLimit")?.getString()?.toIntOrNull() ?: 60
@@ -37,6 +39,7 @@ data class AppConfig(
                 jwtRealm,
                 jwtSecret,
                 fetchCron,
+                cleanupCron,
                 mongoUri,
                 apiKey,
                 anonRateLimit,

--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory
 import pl.cuyer.thedome.domain.battlemetrics.*
 import pl.cuyer.thedome.resources.Servers
 import pl.cuyer.thedome.services.ServerFetchService
+import pl.cuyer.thedome.services.ServerCleanupService
 import pl.cuyer.thedome.services.ServersService
 import pl.cuyer.thedome.services.FiltersService
 import pl.cuyer.thedome.services.AuthService
@@ -182,8 +183,10 @@ fun Application.module() {
     }
 
     val fetchService by inject<ServerFetchService>()
+    val cleanupService by inject<ServerCleanupService>()
     val schedulerClient by inject<MongoClient>()
     logger.info("Scheduling fetch task with cron expression '${config.fetchCron}'")
+    logger.info("Scheduling cleanup task with cron expression '${config.cleanupCron}'")
 
     install(TaskScheduling) {
         mongoDb {
@@ -194,6 +197,11 @@ fun Application.module() {
             name = "fetch-servers"
             kronSchedule = { applyCron(config.fetchCron) }
             task = { fetchService.fetchServers() }
+        }
+        task {
+            name = "cleanup-servers"
+            kronSchedule = { applyCron(config.cleanupCron) }
+            task = { cleanupService.cleanupOldServers() }
         }
     }
 

--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -21,6 +21,7 @@ import org.koin.core.qualifier.named
 import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
 import pl.cuyer.thedome.domain.auth.User
 import pl.cuyer.thedome.services.ServerFetchService
+import pl.cuyer.thedome.services.ServerCleanupService
 import pl.cuyer.thedome.services.ServersService
 import pl.cuyer.thedome.services.FiltersService
 import pl.cuyer.thedome.services.AuthService
@@ -85,6 +86,7 @@ fun appModule(config: AppConfig) = module {
     }
 
     single { ServerFetchService(get(), get(named("servers")), config.apiKey) }
+    single { ServerCleanupService(get(named("servers"))) }
     single { ServersService(get(named("servers"))) }
     single { FiltersService(get(named("servers"))) }
     single { AuthService(get(named("users")), config.jwtSecret, config.jwtIssuer, config.jwtAudience) }

--- a/src/main/kotlin/pl/cuyer/thedome/services/ServerCleanupService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/ServerCleanupService.kt
@@ -1,0 +1,21 @@
+package pl.cuyer.thedome.services
+
+import com.mongodb.client.model.Filters
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import org.slf4j.LoggerFactory
+import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
+import kotlin.time.Duration.Companion.days
+
+class ServerCleanupService(
+    private val collection: MongoCollection<BattlemetricsServerContent>
+) {
+    private val logger = LoggerFactory.getLogger(ServerCleanupService::class.java)
+
+    suspend fun cleanupOldServers() {
+        val cutoff: Instant = Clock.System.now() - 60.days
+        val result = collection.deleteMany(Filters.lt("attributes.updatedAt", cutoff.toString()))
+        logger.info("Removed ${'$'}{result.deletedCount} outdated servers")
+    }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -10,6 +10,7 @@ ktor {
         allowedOrigins = ${?ALLOWED_ORIGINS}
         mongoUri = ${?MONGODB_URI}
         fetchCron = ${?FETCH_CRON}
+        cleanupCron = ${?CLEANUP_CRON}
         anonRateLimit = ${?ANON_RATE_LIMIT}
         anonRefillPeriod = ${?ANON_REFILL_PERIOD}
         favoritesLimit = ${?FAVORITES_LIMIT}

--- a/src/test/kotlin/pl/cuyer/thedome/services/ServerCleanupServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/ServerCleanupServiceTest.kt
@@ -1,0 +1,31 @@
+package pl.cuyer.thedome.services
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.coVerify
+import io.mockk.every
+import kotlinx.coroutines.runBlocking
+import org.bson.conversions.Bson
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ServerCleanupServiceTest {
+    @Test
+    fun `cleanupOldServers removes outdated`() = runBlocking {
+        val collection = mockk<MongoCollection<BattlemetricsServerContent>>(relaxed = true)
+        val filterSlot = slot<Bson>()
+        val result = mockk<com.mongodb.client.result.DeleteResult> {
+            every { deletedCount } returns 5
+        }
+        coEvery { collection.deleteMany(capture(filterSlot), any()) } returns result
+
+        val service = ServerCleanupService(collection)
+        service.cleanupOldServers()
+
+        coVerify(exactly = 1) { collection.deleteMany(any<Bson>(), any()) }
+        assertTrue(filterSlot.captured.toString().contains("attributes.updatedAt"))
+    }
+}


### PR DESCRIPTION
## Summary
- remove deleteMany on unknown servers and schedule cleanup job instead
- make cleanup cron configurable
- log job scheduling
- refactor fetch service tests and add cleanup job test
- document CLEANUP_CRON

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6859d9fd3f988321bf86a7627ed14488