### PR TITLE
Allow configuring token validity

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Values can also be specified in `src/main/resources/application.conf` under the 
 - `ANON_RATE_LIMIT` – requests per minute allowed for anonymous users (default `60`)
 - `ANON_REFILL_PERIOD` – seconds per anonymous rate limit window (default `60`)
 - `FAVORITES_LIMIT` – maximum favourites for non-subscribers and anonymous users (default `10`)
+- `TOKEN_VALIDITY` – access token lifetime in seconds (default `3600`)
+- `ANON_TOKEN_VALIDITY` – anonymous token lifetime in seconds (default `3600`)
 - Unhandled exceptions are logged via Ktor's `StatusPages` plugin
 
 Query servers with optional filtering. Alongside pagination (`page` and `size`),
@@ -151,6 +153,8 @@ You can run the project and its MongoDB dependency using Docker Compose. The pro
 - `CLEANUP_CRON` – cron expression for server cleanup schedule (optional)
 - `API_KEY` – optional RustMaps API key (optional)
 - `PORT` – application port (defaults to `8080`)
+- `TOKEN_VALIDITY` – access token lifetime in seconds (default `3600`)
+- `ANON_TOKEN_VALIDITY` – anonymous token lifetime in seconds (default `3600`)
 
 You can set these in the `compose.yaml` or via an `.env` file.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,8 @@ services:
       # ALLOWED_ORIGINS: "https://example.com,https://example2.com"  # Set allowed CORS origins in production
       # ANON_RATE_LIMIT: 60  # Requests per minute allowed for anonymous users
       # ANON_REFILL_PERIOD: 60  # Seconds per anonymous rate limit window
+      # TOKEN_VALIDITY: 3600  # Access token lifetime in seconds
+      # ANON_TOKEN_VALIDITY: 3600  # Anonymous access token lifetime in seconds
     depends_on:
       - mongo
     networks:

--- a/src/main/kotlin/pl/cuyer/thedome/AppConfig.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/AppConfig.kt
@@ -14,7 +14,9 @@ data class AppConfig(
     val apiKey: String,
     val anonRateLimit: Int,
     val anonRefillPeriod: Int,
-    val favoritesLimit: Int
+    val favoritesLimit: Int,
+    val tokenValidity: Int,
+    val anonTokenValidity: Int
 ) {
     companion object {
         fun load(config: ApplicationConfig): AppConfig {
@@ -32,6 +34,8 @@ data class AppConfig(
             val anonRateLimit = section.propertyOrNull("anonRateLimit")?.getString()?.toIntOrNull() ?: 60
             val anonRefillPeriod = section.propertyOrNull("anonRefillPeriod")?.getString()?.toIntOrNull() ?: 60
             val favoritesLimit = section.propertyOrNull("favoritesLimit")?.getString()?.toIntOrNull() ?: 10
+            val tokenValidity = section.propertyOrNull("tokenValidity")?.getString()?.toIntOrNull() ?: 3600
+            val anonTokenValidity = section.propertyOrNull("anonTokenValidity")?.getString()?.toIntOrNull() ?: 3600
             return AppConfig(
                 allowedOrigins,
                 jwtAudience,
@@ -44,7 +48,9 @@ data class AppConfig(
                 apiKey,
                 anonRateLimit,
                 anonRefillPeriod,
-                favoritesLimit
+                favoritesLimit,
+                tokenValidity,
+                anonTokenValidity
             )
         }
     }

--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -89,6 +89,15 @@ fun appModule(config: AppConfig) = module {
     single { ServerCleanupService(get(named("servers"))) }
     single { ServersService(get(named("servers"))) }
     single { FiltersService(get(named("servers"))) }
-    single { AuthService(get(named("users")), config.jwtSecret, config.jwtIssuer, config.jwtAudience) }
+    single {
+        AuthService(
+            get(named("users")),
+            config.jwtSecret,
+            config.jwtIssuer,
+            config.jwtAudience,
+            config.tokenValidity.toLong() * 1000L,
+            config.anonTokenValidity.toLong() * 1000L
+        )
+    }
     single { FavoritesService(get(named("users")), get(named("servers")), config.favoritesLimit) }
 }

--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -19,7 +19,9 @@ class AuthService(
     private val collection: MongoCollection<User>,
     private val jwtSecret: String,
     private val jwtIssuer: String,
-    private val jwtAudience: String
+    private val jwtAudience: String,
+    private val tokenValidityMs: Long,
+    private val anonTokenValidityMs: Long
 ) {
     private val algorithm = Algorithm.HMAC256(jwtSecret)
     private val logger = LoggerFactory.getLogger(AuthService::class.java)
@@ -39,7 +41,7 @@ class AuthService(
         val user = User(username = username, email = email, passwordHash = hash, refreshToken = hashedRefresh)
         collection.insertOne(user)
         logger.info("User $username registered")
-        return TokenPair(generateAccessToken(user), refresh, username, email)
+        return TokenPair(generateAccessToken(user, tokenValidityMs), refresh, username, email)
     }
 
     suspend fun registerAnonymous(): AccessToken {
@@ -48,7 +50,7 @@ class AuthService(
         val user = User(username = username, passwordHash = "", refreshToken = null)
         collection.insertOne(user)
         logger.info("Anonymous user $username registered")
-        return AccessToken(generateAccessToken(user), username)
+        return AccessToken(generateAccessToken(user, anonTokenValidityMs), username)
     }
 
     suspend fun upgradeAnonymous(currentUsername: String, newUsername: String, password: String): TokenPair? {
@@ -64,7 +66,7 @@ class AuthService(
         collection.updateOne(eq(User::username, newUsername), set(User::refreshToken, hashedRefresh))
         logger.info("Anonymous user $currentUsername upgraded to $newUsername")
         val updated = collection.find(eq(User::username, newUsername)).firstOrNull() ?: return null
-        return TokenPair(generateAccessToken(updated), refresh, newUsername, updated.email)
+        return TokenPair(generateAccessToken(updated, tokenValidityMs), refresh, newUsername, updated.email)
     }
 
     suspend fun login(username: String, password: String): TokenPair? {
@@ -75,7 +77,7 @@ class AuthService(
         val hashedRefresh = hashToken(refresh)
         collection.updateOne(eq(User::username, user.username), set(User::refreshToken, hashedRefresh))
         logger.info("User ${'$'}{user.username} logged in")
-        return TokenPair(generateAccessToken(user), refresh, user.username, user.email)
+        return TokenPair(generateAccessToken(user, tokenValidityMs), refresh, user.username, user.email)
     }
 
     suspend fun refresh(refreshToken: String): TokenPair? {
@@ -86,16 +88,16 @@ class AuthService(
         val hashedNew = hashToken(newRefresh)
         collection.updateOne(eq(User::username, user.username), set(User::refreshToken, hashedNew))
         logger.info("Issued new refresh token for ${'$'}{user.username}")
-        return TokenPair(generateAccessToken(user), newRefresh, user.username, user.email)
+        return TokenPair(generateAccessToken(user, tokenValidityMs), newRefresh, user.username, user.email)
     }
 
-    private fun generateAccessToken(user: User): String {
+    private fun generateAccessToken(user: User, validity: Long): String {
         return JWT.create()
             .withAudience(jwtAudience)
             .withIssuer(jwtIssuer)
             .withClaim("username", user.username)
             .withClaim("email", user.email)
-            .withExpiresAt(Date(System.currentTimeMillis() + 3600_000))
+            .withExpiresAt(Date(System.currentTimeMillis() + validity))
             .sign(algorithm)
     }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,6 +14,8 @@ ktor {
         anonRateLimit = ${?ANON_RATE_LIMIT}
         anonRefillPeriod = ${?ANON_REFILL_PERIOD}
         favoritesLimit = ${?FAVORITES_LIMIT}
+        tokenValidity = ${?TOKEN_VALIDITY}
+        anonTokenValidity = ${?ANON_TOKEN_VALIDITY}
         apiKey = ${?API_KEY}
         jwt {
             secret = ${?JWT_SECRET}

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
@@ -25,7 +25,7 @@ class AuthServiceTest {
     fun `registerAnonymous stores user`() = runBlocking {
         val collection = mockk<MongoCollection<User>>(relaxed = true)
         coEvery { collection.insertOne(any(), any<InsertOneOptions>()) } returns mockk()
-        val service = AuthService(collection, "secret", "issuer", "audience")
+        val service = AuthService(collection, "secret", "issuer", "audience", 3600_000, 3600_000)
 
         val result = service.registerAnonymous()
 
@@ -44,7 +44,7 @@ class AuthServiceTest {
             FindFlow(SimpleFindPublisher(listOf(updated)))
         )
         coEvery { collection.updateOne(any<Bson>(), any<Bson>(), any()) } returns mockk()
-        val service = AuthService(collection, "secret", "issuer", "audience")
+        val service = AuthService(collection, "secret", "issuer", "audience", 3600_000, 3600_000)
 
         val result = service.upgradeAnonymous("anon-123", "newuser", "pass")
 
@@ -63,7 +63,7 @@ class AuthServiceTest {
             FindFlow(SimpleFindPublisher(listOf(user)))
         )
         coEvery { collection.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
-        val service = AuthService(collection, "secret", "issuer", "audience")
+        val service = AuthService(collection, "secret", "issuer", "audience", 3600_000, 3600_000)
 
         val result = service.login("user", "pass")
 
@@ -84,7 +84,7 @@ class AuthServiceTest {
         val slotUpdate = slot<Bson>()
         every { collection.find(capture(slotFind)) } returns FindFlow(SimpleFindPublisher(listOf(user)))
         coEvery { collection.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
-        val service = AuthService(collection, "secret", "issuer", "audience")
+        val service = AuthService(collection, "secret", "issuer", "audience", 3600_000, 3600_000)
 
         val result = service.refresh(oldToken)
 


### PR DESCRIPTION
## Summary
- let AuthService receive validity for regular/anonymous tokens
- expose TOKEN_VALIDITY and ANON_TOKEN_VALIDITY in application config
- wire the new settings through Koin
- document the new environment variables and Docker Compose options
- update tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685b17b5e2d4832198be73be5211b3f4