### PR TITLE
Add next wipe exposure

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
@@ -33,6 +33,7 @@ fun BattlemetricsServerContent.toServerInfo(): ServerInfo =
         id = id.toLongOrNull(),
         name = attributes.name,
         wipe = attributes.details?.rustLastWipe?.let(Instant::parse),
+        nextWipe = attributes.details?.rustNextWipe?.let(Instant::parse),
         status = attributes.status?.uppercase()?.let {
             try {
                 ServerStatus.valueOf(it)

--- a/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
@@ -9,6 +9,8 @@ data class ServerInfo(
     val id: Long? = null,
     val name: String? = null,
     val wipe: Instant? = null,
+    @SerialName("next_wipe")
+    val nextWipe: Instant? = null,
     val status: ServerStatus? = null,
     val ranking: Int? = null,
     val modded: Boolean? = null,

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -212,6 +212,9 @@ components:
         wipe:
           type: string
           format: date-time
+        next_wipe:
+          type: string
+          format: date-time
         status:
           type: string
         ranking:

--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
@@ -70,6 +70,7 @@ class ServerExtensionsAdditionalTest {
         val details = Details(
             map = "Procedural Map",
             rustLastWipe = "2024-01-01T00:00:00Z",
+            rustNextWipe = "2024-01-02T00:00:00Z",
             rustType = "modded",
             rustGamemode = "vanilla",
             rustSettings = settings,
@@ -101,6 +102,7 @@ class ServerExtensionsAdditionalTest {
         assertEquals(1L, info.id)
         assertEquals("Test", info.name)
         assertEquals(Instant.parse("2024-01-01T00:00:00Z"), info.wipe)
+        assertEquals(Instant.parse("2024-01-02T00:00:00Z"), info.nextWipe)
         assertEquals(1, info.ranking)
         assertEquals(true, info.modded)
         assertEquals(10L, info.playerCount)


### PR DESCRIPTION
## Summary
- expose `rust_next_wipe` as `next_wipe` in server info
- document new field in OpenAPI
- test `next_wipe` mapping

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685b204caf2c8321903875ae639f0ff1