### PR TITLE
Add next map wipe field

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensions.kt
@@ -34,6 +34,7 @@ fun BattlemetricsServerContent.toServerInfo(): ServerInfo =
         name = attributes.name,
         wipe = attributes.details?.rustLastWipe?.let(Instant::parse),
         nextWipe = attributes.details?.rustNextWipe?.let(Instant::parse),
+        nextMapWipe = attributes.details?.rustNextWipeMap?.let(Instant::parse),
         status = attributes.status?.uppercase()?.let {
             try {
                 ServerStatus.valueOf(it)

--- a/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/server/ServerInfo.kt
@@ -11,6 +11,8 @@ data class ServerInfo(
     val wipe: Instant? = null,
     @SerialName("next_wipe")
     val nextWipe: Instant? = null,
+    @SerialName("next_map_wipe")
+    val nextMapWipe: Instant? = null,
     val status: ServerStatus? = null,
     val ranking: Int? = null,
     val modded: Boolean? = null,

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -215,6 +215,9 @@ components:
         next_wipe:
           type: string
           format: date-time
+        next_map_wipe:
+          type: string
+          format: date-time
         status:
           type: string
         ranking:

--- a/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/domain/battlemetrics/ServerExtensionsAdditionalTest.kt
@@ -71,6 +71,7 @@ class ServerExtensionsAdditionalTest {
             map = "Procedural Map",
             rustLastWipe = "2024-01-01T00:00:00Z",
             rustNextWipe = "2024-01-02T00:00:00Z",
+            rustNextWipeMap = "2024-01-03T00:00:00Z",
             rustType = "modded",
             rustGamemode = "vanilla",
             rustSettings = settings,
@@ -103,6 +104,7 @@ class ServerExtensionsAdditionalTest {
         assertEquals("Test", info.name)
         assertEquals(Instant.parse("2024-01-01T00:00:00Z"), info.wipe)
         assertEquals(Instant.parse("2024-01-02T00:00:00Z"), info.nextWipe)
+        assertEquals(Instant.parse("2024-01-03T00:00:00Z"), info.nextMapWipe)
         assertEquals(1, info.ranking)
         assertEquals(true, info.modded)
         assertEquals(10L, info.playerCount)


### PR DESCRIPTION
## Summary
- include next map wipe info in ServerInfo model
- parse rust_next_wipe_map from BattleMetrics
- document field in OpenAPI spec
- test nextMapWipe mapping

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685b962c1140832199a734378bf830ae