### PR TITLE
Switch FCM to Firebase Admin SDK

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("io.insert-koin:koin-ktor:$koinVersion")
     implementation("io.insert-koin:koin-logger-slf4j:$koinVersion")
     implementation("com.google.auth:google-auth-library-oauth2-http:1.35.0")
+    implementation("com.google.firebase:firebase-admin:9.5.0")
     implementation("org.mindrot:jbcrypt:0.4")
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.mockk:mockk:1.13.9")

--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -29,6 +29,10 @@ import pl.cuyer.thedome.services.FavoritesService
 import pl.cuyer.thedome.services.SubscriptionsService
 import pl.cuyer.thedome.services.FcmService
 import pl.cuyer.thedome.AppConfig
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.auth.oauth2.GoogleCredentials
 
 fun appModule(config: AppConfig) = module {
     single<Json> { Json { ignoreUnknownKeys = true } }
@@ -37,6 +41,16 @@ fun appModule(config: AppConfig) = module {
         HttpClient(CIO) {
             install(ClientContentNegotiation) { json(get()) }
         }
+    }
+
+    single<FirebaseMessaging> {
+        if (FirebaseApp.getApps().isEmpty()) {
+            val options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.getApplicationDefault())
+                .build()
+            FirebaseApp.initializeApp(options)
+        }
+        FirebaseMessaging.getInstance()
     }
 
     single<MongoClient> {
@@ -107,7 +121,6 @@ fun appModule(config: AppConfig) = module {
         FcmService(
             get(),
             get(named("servers")),
-            get(),
             config.notifyBeforeWipe,
             config.notifyBeforeMapWipe
         )

--- a/src/main/kotlin/pl/cuyer/thedome/services/NotificationType.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/NotificationType.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.thedome.services
+
+enum class NotificationType {
+    MapWipe,
+    Wipe,
+}
+

--- a/src/test/kotlin/pl/cuyer/thedome/services/FcmServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/FcmServiceTest.kt
@@ -1,0 +1,53 @@
+package pl.cuyer.thedome.services
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import com.mongodb.kotlin.client.coroutine.FindFlow
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlin.time.Duration.Companion.seconds
+import org.bson.conversions.Bson
+import pl.cuyer.thedome.domain.battlemetrics.Attributes
+import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
+import pl.cuyer.thedome.domain.battlemetrics.Details
+import pl.cuyer.thedome.util.SimpleFindPublisher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FcmServiceTest {
+    @Test
+    fun `checkAndSend sends message using firebase`() = runBlocking {
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val now = Clock.System.now()
+        val server = BattlemetricsServerContent(
+            attributes = Attributes(
+                id = "a1",
+                name = "Test Server",
+                details = Details(rustNextWipe = (now + 30.seconds).toString())
+            ),
+            id = "1"
+        )
+        val collection = mockk<MongoCollection<BattlemetricsServerContent>>()
+        every { collection.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(server)))
+
+        val service = FcmService(messaging, collection, 1, 0)
+        service.checkAndSend()
+
+        val captured = slot<Message>()
+        verify { messaging.send(capture(captured)) }
+        val message = captured.captured
+        fun field(target: Any, name: String): Any? = target.javaClass.getDeclaredField(name).apply { isAccessible = true }.get(target)
+        assertEquals("1", field(message, "topic"))
+        assertEquals(null, field(message, "notification"))
+        val data = field(message, "data") as Map<*, *>
+        assertEquals("Server wipe", data["title"])
+        assertEquals("Test Server", data["body"])
+        assertEquals("1", data["id"])
+        assertEquals("Wipe", data["type"])
+    }
+}


### PR DESCRIPTION
## Summary
- integrate Firebase Admin SDK
- send wipe type and server id with notifications
- provide `FirebaseMessaging` via Koin
- test FCM notifications
- use data-only FCM messages with `NotificationType` enum

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_685c2fef28748321be780ff168590244