### PR TITLE
Implement FCM token cleanup

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/AppConfig.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/AppConfig.kt
@@ -10,6 +10,7 @@ data class AppConfig(
     val jwtSecret: String,
     val fetchCron: String,
     val cleanupCron: String,
+    val resubscribeCron: String,
     val mongoUri: String,
     val apiKey: String,
     val anonRateLimit: Int,
@@ -33,6 +34,7 @@ data class AppConfig(
             val jwtRealm = jwtSection.propertyOrNull("realm")?.getString() ?: "thedomeRealm"
             val fetchCron = section.propertyOrNull("fetchCron")?.getString() ?: "0 */10 * * *"
             val cleanupCron = section.propertyOrNull("cleanupCron")?.getString() ?: "0 0 * * *"
+            val resubscribeCron = section.propertyOrNull("resubscribeCron")?.getString() ?: "0 0 1 * *"
             val mongoUri = section.propertyOrNull("mongoUri")?.getString() ?: "mongodb://localhost:27017"
             val apiKey = section.propertyOrNull("apiKey")?.getString() ?: ""
             val anonRateLimit = section.propertyOrNull("anonRateLimit")?.getString()?.toIntOrNull() ?: 60
@@ -60,6 +62,7 @@ data class AppConfig(
                 jwtSecret,
                 fetchCron,
                 cleanupCron,
+                resubscribeCron,
                 mongoUri,
                 apiKey,
                 anonRateLimit,

--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -27,6 +27,7 @@ import pl.cuyer.thedome.services.FiltersService
 import pl.cuyer.thedome.services.AuthService
 import pl.cuyer.thedome.services.FavouritesService
 import pl.cuyer.thedome.services.SubscriptionsService
+import pl.cuyer.thedome.services.FcmTokenService
 import pl.cuyer.thedome.services.FcmService
 import pl.cuyer.thedome.AppConfig
 import com.google.firebase.FirebaseApp
@@ -127,13 +128,16 @@ fun appModule(config: AppConfig) = module {
         )
     }
     single { FavouritesService(get(named("users")), get(named("servers")), config.favouritesLimit) }
-    single { SubscriptionsService(get(named("users")), config.subscriptionsLimit) }
+    single { SubscriptionsService(get(named("users")), config.subscriptionsLimit, get()) }
+    single { FcmTokenService(get(named("users")), get()) }
     single {
         FcmService(
             get(),
             get(named("servers")),
             config.notifyBeforeWipe,
             config.notifyBeforeMapWipe,
+            get(),
+            get(named("users")),
             get()
         )
     }

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/FcmToken.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/FcmToken.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.thedome.domain.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmToken(
+    val token: String,
+    val updatedAt: String
+)

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/User.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/User.kt
@@ -16,5 +16,7 @@ data class User(
     val refreshToken: String? = null,
     val subscriber: Boolean = false,
     val favourites: List<String> = emptyList(),
-    val subscriptions: List<String> = emptyList()
+    val subscriptions: List<String> = emptyList(),
+    val fcmTokens: List<FcmToken> = emptyList()
 )
+

--- a/src/main/kotlin/pl/cuyer/thedome/domain/fcm/FcmTokenRequest.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/fcm/FcmTokenRequest.kt
@@ -1,0 +1,10 @@
+package pl.cuyer.thedome.domain.fcm
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmTokenRequest(
+    val token: String,
+    val timestamp: String
+)
+

--- a/src/main/kotlin/pl/cuyer/thedome/routes/FcmTokenEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/FcmTokenEndpoint.kt
@@ -1,0 +1,36 @@
+package pl.cuyer.thedome.routes
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import pl.cuyer.thedome.domain.fcm.FcmTokenRequest
+import pl.cuyer.thedome.services.FcmTokenService
+
+class FcmTokenEndpoint(private val service: FcmTokenService) {
+    fun register(route: Route) {
+        with(route) {
+            authenticate("auth-jwt") {
+                post("/fcm/token") {
+                    val principal = call.principal<JWTPrincipal>()!!
+                    val username = principal.getClaim("username", String::class)!!
+                    val req = call.receive<FcmTokenRequest>()
+                    service.registerToken(username, req.token, req.timestamp)
+                    call.respond(HttpStatusCode.Created)
+                }
+                delete("/fcm/token/{token}") {
+                    val principal = call.principal<JWTPrincipal>()!!
+                    val username = principal.getClaim("username", String::class)!!
+                    val token = call.parameters["token"] ?: return@delete call.respond(HttpStatusCode.BadRequest)
+                    service.removeToken(username, token)
+                    call.respond(HttpStatusCode.NoContent)
+                }
+            }
+        }
+    }
+}
+

--- a/src/main/kotlin/pl/cuyer/thedome/services/FcmTokenService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/FcmTokenService.kt
@@ -1,0 +1,80 @@
+package pl.cuyer.thedome.services
+
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import com.mongodb.kotlin.client.model.Filters.eq
+import com.mongodb.kotlin.client.model.Filters.ne
+import com.mongodb.kotlin.client.model.Updates.set
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.toList
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.plus
+import kotlin.time.Duration.Companion.days
+import com.google.firebase.messaging.FirebaseMessaging
+import pl.cuyer.thedome.domain.auth.FcmToken
+import pl.cuyer.thedome.domain.auth.User
+
+class FcmTokenService(
+    private val users: MongoCollection<User>,
+    private val messaging: FirebaseMessaging
+) {
+    suspend fun registerToken(username: String, token: String, timestamp: String) {
+        val user = users.find(eq(User::username, username)).firstOrNull() ?: return
+        val exists = user.fcmTokens.any { it.token == token }
+        val newTokens = user.fcmTokens.filter { it.token != token } + FcmToken(token, timestamp)
+        users.updateOne(eq(User::username, username), set(User::fcmTokens, newTokens))
+        if (!exists && user.subscriptions.isNotEmpty()) {
+            for (topic in user.subscriptions) {
+                try {
+                    messaging.subscribeToTopic(listOf(token), topic)
+                } catch (_: Exception) {}
+            }
+        }
+    }
+
+    suspend fun removeToken(username: String, token: String) {
+        val user = users.find(eq(User::username, username)).firstOrNull() ?: return
+        val newTokens = user.fcmTokens.filter { it.token != token }
+        users.updateOne(eq(User::username, username), set(User::fcmTokens, newTokens))
+        if (user.subscriptions.isNotEmpty()) {
+            for (topic in user.subscriptions) {
+                try {
+                    messaging.unsubscribeFromTopic(listOf(token), topic)
+                } catch (_: Exception) {}
+            }
+        }
+    }
+
+    suspend fun removeStaleTokens(days: Int = 30) {
+        val cutoff = Clock.System.now() - days.days
+        val candidates = users.find(ne(User::fcmTokens, emptyList<FcmToken>())).toList()
+        for (user in candidates) {
+            val stale = user.fcmTokens.filter { Instant.parse(it.updatedAt) < cutoff }
+            if (stale.isNotEmpty()) {
+                val remaining = user.fcmTokens.filter { Instant.parse(it.updatedAt) >= cutoff }
+                users.updateOne(eq(User::username, user.username), set(User::fcmTokens, remaining))
+                if (user.subscriptions.isNotEmpty()) {
+                    for (topic in user.subscriptions) {
+                        try {
+                            messaging.unsubscribeFromTopic(stale.map { it.token }, topic)
+                        } catch (_: Exception) {}
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun resubscribeTokens() {
+        val candidates = users.find(ne(User::fcmTokens, emptyList<FcmToken>())).toList()
+        for (user in candidates) {
+            if (user.subscriptions.isEmpty()) continue
+            val tokens = user.fcmTokens.map { it.token }
+            for (topic in user.subscriptions) {
+                try {
+                    messaging.subscribeToTopic(tokens, topic)
+                } catch (_: Exception) {}
+            }
+        }
+    }
+}
+

--- a/src/main/kotlin/pl/cuyer/thedome/services/SubscriptionsService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/SubscriptionsService.kt
@@ -4,13 +4,15 @@ import com.mongodb.kotlin.client.coroutine.MongoCollection
 import com.mongodb.kotlin.client.model.Filters.eq
 import com.mongodb.kotlin.client.model.Updates.push
 import com.mongodb.kotlin.client.model.Updates.pull
+import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.flow.firstOrNull
 import pl.cuyer.thedome.domain.auth.User
 import pl.cuyer.thedome.exceptions.SubscriptionLimitException
 
 class SubscriptionsService(
     private val users: MongoCollection<User>,
-    private val limit: Int
+    private val limit: Int,
+    private val messaging: FirebaseMessaging
 ) {
     suspend fun getSubscriptions(username: String): List<String> {
         val user = users.find(eq(User::username, username)).firstOrNull()
@@ -22,6 +24,11 @@ class SubscriptionsService(
         if (user.subscriptions.contains(serverId)) return true
         if (!user.subscriber && user.subscriptions.size >= limit) throw SubscriptionLimitException()
         users.updateOne(eq(User::username, username), push(User::subscriptions, serverId))
+        if (user.fcmTokens.isNotEmpty()) {
+            try {
+                messaging.subscribeToTopic(user.fcmTokens.map { it.token }, serverId)
+            } catch (_: Exception) {}
+        }
         return true
     }
 
@@ -29,6 +36,11 @@ class SubscriptionsService(
         val user = users.find(eq(User::username, username)).firstOrNull() ?: return false
         if (!user.subscriptions.contains(serverId)) return false
         users.updateOne(eq(User::username, username), pull(User::subscriptions, serverId))
+        if (user.fcmTokens.isNotEmpty()) {
+            try {
+                messaging.unsubscribeFromTopic(user.fcmTokens.map { it.token }, serverId)
+            } catch (_: Exception) {}
+        }
         return true
     }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -11,6 +11,7 @@ ktor {
         mongoUri = ${?MONGODB_URI}
         fetchCron = ${?FETCH_CRON}
         cleanupCron = ${?CLEANUP_CRON}
+        resubscribeCron = ${?RESUBSCRIBE_CRON}
         anonRateLimit = ${?ANON_RATE_LIMIT}
         anonRefillPeriod = ${?ANON_REFILL_PERIOD}
         favouritesLimit = ${?FAVOURITES_LIMIT}

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -200,6 +200,32 @@ paths:
         '401':
           description: Invalid refresh token
 
+  /fcm/token:
+    post:
+      summary: Register FCM token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FcmTokenRequest'
+      responses:
+        '201':
+          description: Token registered
+
+  /fcm/token/{token}:
+    delete:
+      summary: Delete FCM token
+      parameters:
+        - in: path
+          name: token
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Token removed
+
 components:
   schemas:
     ServerInfo:
@@ -365,6 +391,13 @@ components:
         accessToken:
           type: string
         username:
+          type: string
+    FcmTokenRequest:
+      type: object
+      properties:
+        token:
+          type: string
+        timestamp:
           type: string
     UpgradeRequest:
       type: object

--- a/src/test/kotlin/pl/cuyer/thedome/services/FcmServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/FcmServiceTest.kt
@@ -2,6 +2,8 @@ package pl.cuyer.thedome.services
 
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
 import com.google.auth.oauth2.GoogleCredentials
 import com.mongodb.kotlin.client.coroutine.MongoCollection
 import com.mongodb.kotlin.client.coroutine.FindFlow
@@ -9,6 +11,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.mockk.coEvery
+import io.mockk.coVerify
+import pl.cuyer.thedome.domain.auth.FcmToken
+import pl.cuyer.thedome.services.FcmTokenService
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import kotlin.time.Duration.Companion.seconds
@@ -16,6 +22,7 @@ import org.bson.conversions.Bson
 import pl.cuyer.thedome.domain.battlemetrics.Attributes
 import pl.cuyer.thedome.domain.battlemetrics.BattlemetricsServerContent
 import pl.cuyer.thedome.domain.battlemetrics.Details
+import pl.cuyer.thedome.domain.auth.User
 import pl.cuyer.thedome.util.SimpleFindPublisher
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,6 +32,7 @@ class FcmServiceTest {
     fun `checkAndSend sends message using firebase`() = runBlocking {
         val messaging = mockk<FirebaseMessaging>(relaxed = true)
         val credentials = mockk<GoogleCredentials>(relaxed = true)
+        val tokenService = mockk<FcmTokenService>(relaxed = true)
         val now = Clock.System.now()
         val server = BattlemetricsServerContent(
             attributes = Attributes(
@@ -34,22 +42,55 @@ class FcmServiceTest {
             ),
             id = "1"
         )
-        val collection = mockk<MongoCollection<BattlemetricsServerContent>>()
-        every { collection.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(server)))
+        val serverColl = mockk<MongoCollection<BattlemetricsServerContent>>()
+        every { serverColl.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(server)))
+        val usersColl = mockk<MongoCollection<User>>()
+        val user = User(username = "user", passwordHash = "", subscriptions = listOf("1"), fcmTokens = listOf(FcmToken("t1", "ts")))
+        every { usersColl.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
 
-        val service = FcmService(messaging, collection, listOf(1), emptyList(), credentials)
+        val service = FcmService(messaging, serverColl, listOf(1), emptyList(), credentials, usersColl, tokenService)
         service.checkAndSend()
 
         val captured = slot<Message>()
         verify { credentials.refreshIfExpired() }
-        verify { messaging.sendAsync(capture(captured)) }
+        verify { messaging.send(capture(captured)) }
         val message = captured.captured
         fun field(target: Any, name: String): Any? = target.javaClass.getDeclaredField(name).apply { isAccessible = true }.get(target)
-        assertEquals("1", field(message, "topic"))
+        assertEquals("t1", field(message, "token"))
         assertEquals(null, field(message, "notification"))
         val data = field(message, "data") as Map<*, *>
         assertEquals("Test Server", data["name"])
         assertEquals("Wipe", data["type"])
         assertEquals((now + 30.seconds).toString(), data["timestamp"])
+    }
+
+    @Test
+    fun `invalid token is removed`() = runBlocking {
+        val exception = mockk<FirebaseMessagingException>()
+        every { exception.messagingErrorCode } returns MessagingErrorCode.UNREGISTERED
+        every { exception.message } returns "error"
+        val messaging = mockk<FirebaseMessaging>()
+        every { messaging.send(any()) } throws exception
+        val credentials = mockk<GoogleCredentials>(relaxed = true)
+        val tokenService = mockk<FcmTokenService>(relaxed = true)
+        val now = Clock.System.now()
+        val server = BattlemetricsServerContent(
+            attributes = Attributes(
+                id = "a1",
+                name = "Test Server",
+                details = Details(rustNextWipe = (now + 30.seconds).toString())
+            ),
+            id = "1"
+        )
+        val serverColl = mockk<MongoCollection<BattlemetricsServerContent>>()
+        every { serverColl.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(server)))
+        val usersColl = mockk<MongoCollection<User>>()
+        val user = User(username = "user", passwordHash = "", subscriptions = listOf("1"), fcmTokens = listOf(FcmToken("t1", "ts")))
+        every { usersColl.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
+
+        val service = FcmService(messaging, serverColl, listOf(1), emptyList(), credentials, usersColl, tokenService)
+        service.checkAndSend()
+
+        coVerify { tokenService.removeToken("user", "t1") }
     }
 }

--- a/src/test/kotlin/pl/cuyer/thedome/services/FcmTokenServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/FcmTokenServiceTest.kt
@@ -1,0 +1,86 @@
+package pl.cuyer.thedome.services
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import com.mongodb.kotlin.client.coroutine.FindFlow
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.datetime.Clock
+import kotlin.time.Duration.Companion.days
+import org.bson.conversions.Bson
+import pl.cuyer.thedome.domain.auth.User
+import pl.cuyer.thedome.domain.auth.FcmToken
+import pl.cuyer.thedome.util.SimpleFindPublisher
+
+class FcmTokenServiceTest {
+    @Test
+    fun `registerToken adds token with timestamp and subscribes`() = runBlocking {
+        val users = mockk<MongoCollection<User>>(relaxed = true)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val user = User(username = "user", email = null, passwordHash = "", subscriptions = listOf("s1"))
+        val slotUpdate = slot<Bson>()
+        every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
+        coEvery { users.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
+        val service = FcmTokenService(users, messaging)
+
+        service.registerToken("user", "token1", "ts")
+
+        assertTrue(slotUpdate.captured.toString().contains("token1"))
+        verify { messaging.subscribeToTopic(listOf("token1"), "s1") }
+    }
+
+    @Test
+    fun `removeToken removes token`() = runBlocking {
+        val users = mockk<MongoCollection<User>>(relaxed = true)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val user = User(username = "user", email = null, passwordHash = "", fcmTokens = listOf(FcmToken("token1", "ts")), subscriptions = listOf("s1"))
+        val slotUpdate = slot<Bson>()
+        every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
+        coEvery { users.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
+        val service = FcmTokenService(users, messaging)
+
+        service.removeToken("user", "token1")
+
+        verify { messaging.unsubscribeFromTopic(listOf("token1"), "s1") }
+        assertTrue(slotUpdate.captured.toString().contains("fcmTokens"))
+    }
+
+    @Test
+    fun `removeStaleTokens removes old tokens and unsubscribes`() = runBlocking {
+        val users = mockk<MongoCollection<User>>(relaxed = true)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val old = FcmToken("t1", (Clock.System.now() - 40.days).toString())
+        val fresh = FcmToken("t2", Clock.System.now().toString())
+        val user = User(username = "user", passwordHash = "", fcmTokens = listOf(old, fresh), subscriptions = listOf("s1"))
+        val slotUpdate = slot<Bson>()
+        every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
+        coEvery { users.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
+        val service = FcmTokenService(users, messaging)
+
+        service.removeStaleTokens(30)
+
+        assertTrue(slotUpdate.captured.toString().contains("t2"))
+        verify { messaging.unsubscribeFromTopic(listOf("t1"), "s1") }
+    }
+
+    @Test
+    fun `resubscribeTokens subscribes tokens again`() = runBlocking {
+        val users = mockk<MongoCollection<User>>(relaxed = true)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val user = User(
+            username = "user",
+            passwordHash = "",
+            fcmTokens = listOf(FcmToken("t1", "ts")),
+            subscriptions = listOf("s1")
+        )
+        every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
+        val service = FcmTokenService(users, messaging)
+
+        service.resubscribeTokens()
+
+        verify { messaging.subscribeToTopic(listOf("t1"), "s1") }
+    }
+}
+

--- a/src/test/kotlin/pl/cuyer/thedome/services/SubscriptionsServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/SubscriptionsServiceTest.kt
@@ -9,8 +9,10 @@ import kotlin.test.assertFailsWith
 import com.mongodb.kotlin.client.coroutine.MongoCollection
 import com.mongodb.kotlin.client.coroutine.FindFlow
 import com.mongodb.kotlin.client.model.Filters.eq
+import com.google.firebase.messaging.FirebaseMessaging
 import org.bson.conversions.Bson
 import pl.cuyer.thedome.domain.auth.User
+import pl.cuyer.thedome.domain.auth.FcmToken
 import pl.cuyer.thedome.util.SimpleFindPublisher
 import pl.cuyer.thedome.exceptions.SubscriptionLimitException
 
@@ -18,16 +20,18 @@ class SubscriptionsServiceTest {
     @Test
     fun `subscribe pushes id`() = runBlocking {
         val users = mockk<MongoCollection<User>>(relaxed = true)
-        val user = User(username = "user", email = null, passwordHash = "", subscriptions = emptyList())
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val user = User(username = "user", email = null, passwordHash = "", subscriptions = emptyList(), fcmTokens = listOf(FcmToken("token1", "ts")))
         val slotUpdate = slot<Bson>()
         every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
         coEvery { users.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
-        val service = SubscriptionsService(users, 3)
+        val service = SubscriptionsService(users, 3, messaging)
 
         val result = service.subscribe("user", "1")
 
         assertTrue(result)
         assertTrue(slotUpdate.captured.toString().contains("1"))
+        verify { messaging.subscribeToTopic(listOf("token1"), "1") }
     }
 
     @Test
@@ -35,7 +39,8 @@ class SubscriptionsServiceTest {
         val users = mockk<MongoCollection<User>>(relaxed = true)
         val user = User(username = "user", email = null, passwordHash = "", subscriptions = listOf("1", "2", "3"))
         every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
-        val service = SubscriptionsService(users, 3)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val service = SubscriptionsService(users, 3, messaging)
         assertFailsWith<SubscriptionLimitException> {
             service.subscribe("user", "4")
         }
@@ -48,7 +53,8 @@ class SubscriptionsServiceTest {
         val user = User(username = "user", email = null, passwordHash = "", subscriptions = listOf("1", "2", "3"), subscriber = true)
         every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
         coEvery { users.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
-        val service = SubscriptionsService(users, 3)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val service = SubscriptionsService(users, 3, messaging)
 
         val result = service.subscribe("user", "4")
 
@@ -59,16 +65,18 @@ class SubscriptionsServiceTest {
     @Test
     fun `unsubscribe pulls id`() = runBlocking {
         val users = mockk<MongoCollection<User>>(relaxed = true)
-        val user = User(username = "user", email = null, passwordHash = "", subscriptions = listOf("1"))
+        val user = User(username = "user", email = null, passwordHash = "", subscriptions = listOf("1"), fcmTokens = listOf(FcmToken("token1", "ts")))
         val slotUpdate = slot<Bson>()
         every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
         coEvery { users.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
-        val service = SubscriptionsService(users, 3)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val service = SubscriptionsService(users, 3, messaging)
 
         val result = service.unsubscribe("user", "1")
 
         assertTrue(result)
         assertTrue(slotUpdate.captured.toString().contains("1"))
+        verify { messaging.unsubscribeFromTopic(listOf("token1"), "1") }
     }
 
     @Test
@@ -76,7 +84,8 @@ class SubscriptionsServiceTest {
         val users = mockk<MongoCollection<User>>(relaxed = true)
         val user = User(username = "user", email = null, passwordHash = "", subscriptions = emptyList())
         every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
-        val service = SubscriptionsService(users, 3)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val service = SubscriptionsService(users, 3, messaging)
 
         val result = service.unsubscribe("user", "1")
 


### PR DESCRIPTION
## Summary
- support timestamp in `FcmTokenRequest`
- unsubscribe tokens from topics when removed
- periodically remove stale tokens via scheduled task
- update tests for new FCM token service logic
- resubscribe tokens on registration and monthly
- document new token endpoints in Swagger

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_685f1062f3588321ad05c5b4ea200b8d