### PR TITLE
Use server timestamp for FCM tokens

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/routes/FcmTokenEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/FcmTokenEndpoint.kt
@@ -19,7 +19,7 @@ class FcmTokenEndpoint(private val service: FcmTokenService) {
                     val principal = call.principal<JWTPrincipal>()!!
                     val username = principal.getClaim("username", String::class)!!
                     val req = call.receive<FcmTokenRequest>()
-                    service.registerToken(username, req.token, req.timestamp)
+                    service.registerToken(username, req.token)
                     call.respond(HttpStatusCode.Created)
                 }
                 delete("/fcm/token/{token}") {

--- a/src/main/kotlin/pl/cuyer/thedome/services/FcmTokenService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/FcmTokenService.kt
@@ -18,10 +18,11 @@ class FcmTokenService(
     private val users: MongoCollection<User>,
     private val messaging: FirebaseMessaging
 ) {
-    suspend fun registerToken(username: String, token: String, timestamp: String) {
+    suspend fun registerToken(username: String, token: String) {
         val user = users.find(eq(User::username, username)).firstOrNull() ?: return
         val exists = user.fcmTokens.any { it.token == token }
-        val newTokens = user.fcmTokens.filter { it.token != token } + FcmToken(token, timestamp)
+        val newTokens = user.fcmTokens.filter { it.token != token } +
+            FcmToken(token, Clock.System.now().toString())
         users.updateOne(eq(User::username, username), set(User::fcmTokens, newTokens))
         if (!exists && user.subscriptions.isNotEmpty()) {
             for (topic in user.subscriptions) {

--- a/src/test/kotlin/pl/cuyer/thedome/services/FcmTokenServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/FcmTokenServiceTest.kt
@@ -25,7 +25,7 @@ class FcmTokenServiceTest {
         coEvery { users.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
         val service = FcmTokenService(users, messaging)
 
-        service.registerToken("user", "token1", "ts")
+        service.registerToken("user", "token1")
 
         assertTrue(slotUpdate.captured.toString().contains("token1"))
         verify { messaging.subscribeToTopic(listOf("token1"), "s1") }


### PR DESCRIPTION
## Summary
- ignore client timestamp in `registerToken`
- set updatedAt using `Clock.System.now()`
- adapt endpoint and tests to new signature

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6860686f1b008321847df73a3a3d83ca