### PR TITLE
Switch FCM notifications to topic messaging

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/services/FcmTokenService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/FcmTokenService.kt
@@ -11,6 +11,8 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.plus
 import kotlin.time.Duration.Companion.days
 import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
 import pl.cuyer.thedome.domain.auth.FcmToken
 import pl.cuyer.thedome.domain.auth.User
 
@@ -27,7 +29,13 @@ class FcmTokenService(
             for (topic in user.subscriptions) {
                 try {
                     messaging.subscribeToTopic(listOf(token), topic)
-                } catch (_: Exception) {}
+                } catch (e: Exception) {
+                    if (e is FirebaseMessagingException &&
+                        (e.messagingErrorCode == MessagingErrorCode.UNREGISTERED ||
+                            e.messagingErrorCode == MessagingErrorCode.INVALID_ARGUMENT)) {
+                        removeToken(username, token)
+                    }
+                }
             }
         }
     }
@@ -40,7 +48,13 @@ class FcmTokenService(
             for (topic in user.subscriptions) {
                 try {
                     messaging.unsubscribeFromTopic(listOf(token), topic)
-                } catch (_: Exception) {}
+                } catch (e: Exception) {
+                    if (e is FirebaseMessagingException &&
+                        (e.messagingErrorCode == MessagingErrorCode.UNREGISTERED ||
+                            e.messagingErrorCode == MessagingErrorCode.INVALID_ARGUMENT)) {
+                        // token already invalid, ignore
+                    }
+                }
             }
         }
     }

--- a/src/test/kotlin/pl/cuyer/thedome/services/FcmTokenServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/FcmTokenServiceTest.kt
@@ -7,6 +7,8 @@ import kotlin.test.assertTrue
 import com.mongodb.kotlin.client.coroutine.MongoCollection
 import com.mongodb.kotlin.client.coroutine.FindFlow
 import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
 import kotlinx.datetime.Clock
 import kotlin.time.Duration.Companion.days
 import org.bson.conversions.Bson
@@ -32,9 +34,48 @@ class FcmTokenServiceTest {
     }
 
     @Test
+    fun `registerToken removes invalid token on subscribe failure`() = runBlocking {
+        val users = mockk<MongoCollection<User>>(relaxed = true)
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val exception = mockk<FirebaseMessagingException>()
+        every { exception.messagingErrorCode } returns MessagingErrorCode.UNREGISTERED
+        every { messaging.subscribeToTopic(listOf("token1"), "s1") } throws exception
+        val user = User(username = "user", email = null, passwordHash = "", subscriptions = listOf("s1"))
+        val updates = mutableListOf<Bson>()
+        every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
+        coEvery { users.updateOne(any<Bson>(), capture(updates), any()) } returns mockk()
+        val service = FcmTokenService(users, messaging)
+
+        service.registerToken("user", "token1", "ts")
+
+        assertTrue(updates.size == 2)
+        assertTrue(!updates.last().toString().contains("token1"))
+        verify { messaging.unsubscribeFromTopic(listOf("token1"), "s1") }
+    }
+
+    @Test
     fun `removeToken removes token`() = runBlocking {
         val users = mockk<MongoCollection<User>>(relaxed = true)
         val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        val user = User(username = "user", email = null, passwordHash = "", fcmTokens = listOf(FcmToken("token1", "ts")), subscriptions = listOf("s1"))
+        val slotUpdate = slot<Bson>()
+        every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
+        coEvery { users.updateOne(any<Bson>(), capture(slotUpdate), any()) } returns mockk()
+        val service = FcmTokenService(users, messaging)
+
+        service.removeToken("user", "token1")
+
+        verify { messaging.unsubscribeFromTopic(listOf("token1"), "s1") }
+        assertTrue(slotUpdate.captured.toString().contains("fcmTokens"))
+    }
+
+    @Test
+    fun `removeToken still removes when unsubscribe fails`() = runBlocking {
+        val users = mockk<MongoCollection<User>>(relaxed = true)
+        val messaging = mockk<FirebaseMessaging>()
+        val exception = mockk<FirebaseMessagingException>()
+        every { exception.messagingErrorCode } returns MessagingErrorCode.INVALID_ARGUMENT
+        every { messaging.unsubscribeFromTopic(listOf("token1"), "s1") } throws exception
         val user = User(username = "user", email = null, passwordHash = "", fcmTokens = listOf(FcmToken("token1", "ts")), subscriptions = listOf("s1"))
         val slotUpdate = slot<Bson>()
         every { users.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))


### PR DESCRIPTION
## Summary
- use Firebase topics instead of individual tokens in `FcmService`
- remove token cleanup on send failures
- catch `FirebaseMessagingException` when subscribing/unsubscribing tokens
- drop invalid tokens when topic subscription fails

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6860686eee5c8321bfa24d4449bb3618