### PR TITLE
Implement topic resubscribe on login

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/di/KoinModules.kt
@@ -124,7 +124,8 @@ fun appModule(config: AppConfig) = module {
             config.jwtIssuer,
             config.jwtAudience,
             config.tokenValidity.toLong() * 1000L,
-            config.anonTokenValidity.toLong() * 1000L
+            config.anonTokenValidity.toLong() * 1000L,
+            get()
         )
     }
     single { FavouritesService(get(named("users")), get(named("servers")), config.favouritesLimit) }


### PR DESCRIPTION
## Summary
- resubscribe FCM topics when a user logs in
- expose helper to resubscribe topics for a single user
- update Koin wiring for the new AuthService dependency
- extend unit tests for new behaviour

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68627d07d6ec83218f4d0b828d7581fa