### PR TITLE
Allow deleting Google accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ curl -X POST http://localhost:8080/auth/login \
   -d '{"username":"user","password":"password"}'
 ```
 
-Use the returned `accessToken` in the `Authorization` header (e.g. `Bearer <token>`) when calling `/servers` or `/filters/options`. When you register or log in, a `refreshToken` is also returned. Call `/auth/logout` with your access token to invalidate the session and remove all push notification tokens. To permanently remove an account send your credentials to `/auth/delete`; if they match, the user and associated FCM tokens are deleted and unsubscribed.
+Use the returned `accessToken` in the `Authorization` header (e.g. `Bearer <token>`) when calling `/servers` or `/filters/options`. When you register or log in, a `refreshToken` is also returned. Call `/auth/logout` with your access token to invalidate the session and remove all push notification tokens. To permanently remove an account send a POST request to `/auth/delete` with your access token. If the account was created with a password include it in the request body; Google sign-in accounts can be deleted without providing credentials. All FCM tokens are unsubscribed upon deletion.
 
 
 Example request:

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/DeleteAccountRequest.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/DeleteAccountRequest.kt
@@ -4,6 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DeleteAccountRequest(
-    val username: String,
-    val password: String
+    val password: String? = null
 )

--- a/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
@@ -71,12 +71,15 @@ class AuthEndpoint(private val service: AuthService) {
                         if (!result) throw InvalidCredentialsException()
                         call.respond(HttpStatusCode.NoContent)
                     }
-                }
-                post("/delete") {
-                    val req = call.receive<DeleteAccountRequest>()
-                    val deleted = service.deleteAccount(req.username, req.password)
-                    if (!deleted) throw InvalidCredentialsException()
-                    call.respond(HttpStatusCode.NoContent)
+                    post("/delete") {
+                        val principal = call.principal<JWTPrincipal>()!!
+                        val username = principal.getClaim("username", String::class)!!
+                        val req = try { call.receive<DeleteAccountRequest>() } catch (_: Exception) { null }
+                        val password = req?.password
+                        val deleted = service.deleteAccount(username, password)
+                        if (!deleted) throw InvalidCredentialsException()
+                        call.respond(HttpStatusCode.NoContent)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -152,9 +152,11 @@ class AuthService(
         return true
     }
 
-    suspend fun deleteAccount(username: String, password: String): Boolean {
+    suspend fun deleteAccount(username: String, password: String?): Boolean {
         val user = collection.find(eq(User::username, username)).firstOrNull() ?: return false
-        if (!BCrypt.checkpw(password, user.passwordHash)) return false
+        if (user.googleId == null) {
+            if (password == null || !BCrypt.checkpw(password, user.passwordHash)) return false
+        }
         for (t in user.fcmTokens) {
             tokenService.removeToken(username, t.token)
         }


### PR DESCRIPTION
## Summary
- allow account deletion for Google sign-in users
- move `/auth/delete` behind JWT auth and make password optional
- update docs for new delete workflow
- test deleting Google accounts

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6862976d5d0883219cd1f942527565d2