### PR TITLE
Add auth provider handling

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/AccessToken.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/AccessToken.kt
@@ -1,6 +1,11 @@
 package pl.cuyer.thedome.domain.auth
 
 import kotlinx.serialization.Serializable
+import pl.cuyer.thedome.domain.auth.AuthProvider
 
 @Serializable
-data class AccessToken(val accessToken: String, val username: String)
+data class AccessToken(
+    val accessToken: String,
+    val username: String,
+    val provider: AuthProvider
+)

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/AuthProvider.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/AuthProvider.kt
@@ -1,0 +1,10 @@
+package pl.cuyer.thedome.domain.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class AuthProvider {
+    LOCAL,
+    GOOGLE,
+    ANONYMOUS
+}

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/TokenPair.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/TokenPair.kt
@@ -1,11 +1,13 @@
 package pl.cuyer.thedome.domain.auth
 
 import kotlinx.serialization.Serializable
+import pl.cuyer.thedome.domain.auth.AuthProvider
 
 @Serializable
 data class TokenPair(
     val accessToken: String,
     val refreshToken: String,
     val username: String,
-    val email: String?
+    val email: String?,
+    val provider: AuthProvider
 )

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/User.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/User.kt
@@ -2,6 +2,7 @@ package pl.cuyer.thedome.domain.auth
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import pl.cuyer.thedome.domain.auth.AuthProvider
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId
 
@@ -13,6 +14,7 @@ data class User(
     val username: String,
     val email: String? = null,
     val googleId: String? = null,
+    val provider: AuthProvider = AuthProvider.LOCAL,
     val passwordHash: String,
     val refreshToken: String? = null,
     val testEndsAt: String? = null,

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceGoogleTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceGoogleTest.kt
@@ -54,6 +54,7 @@ class AuthServiceGoogleTest {
         val result = service.loginWithGoogle("token")
 
         assertTrue(result?.username?.startsWith("e") == true)
+        assertTrue(result?.provider == AuthProvider.GOOGLE)
         coVerify { collection.insertOne(match { it.googleId == "sub1" }, any<InsertOneOptions>()) }
     }
 }


### PR DESCRIPTION
## Summary
- track auth provider for each user
- include auth provider in access and refresh tokens
- provide auth provider info when registering/login
- adjust login logic for google
- update tests for new provider field

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6862abc140608321aa168eb9d04bb9a9