### PR TITLE
Add google client ID endpoint

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -50,6 +50,7 @@ import pl.cuyer.thedome.routes.AuthEndpoint
 import pl.cuyer.thedome.routes.FavouritesEndpoint
 import pl.cuyer.thedome.routes.SubscriptionsEndpoint
 import pl.cuyer.thedome.routes.FcmTokenEndpoint
+import pl.cuyer.thedome.routes.ConfigEndpoint
 import io.ktor.server.plugins.ratelimit.*
 import kotlin.time.Duration.Companion.seconds
 import org.koin.ktor.plugin.Koin
@@ -263,12 +264,14 @@ fun Application.module() {
     val serversEndpoint = ServersEndpoint(serversService, favouritesService, subscriptionsService)
     val filtersEndpoint = FiltersEndpoint(filtersService)
     val authEndpoint = AuthEndpoint(authService)
+    val configEndpoint = ConfigEndpoint(config)
     val favouritesEndpoint = FavouritesEndpoint(favouritesService)
     val subscriptionsEndpoint = SubscriptionsEndpoint(subscriptionsService)
     val fcmTokenEndpoint = FcmTokenEndpoint(fcmTokenService)
 
     routing {
         authEndpoint.register(this)
+        configEndpoint.register(this)
 
         authenticate("auth-jwt") {
             get("/") {

--- a/src/main/kotlin/pl/cuyer/thedome/routes/ConfigEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/ConfigEndpoint.kt
@@ -1,0 +1,16 @@
+package pl.cuyer.thedome.routes
+
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import pl.cuyer.thedome.AppConfig
+
+class ConfigEndpoint(private val config: AppConfig) {
+    fun register(route: Route) {
+        with(route) {
+            get("/google-client-id") {
+                call.respond(mapOf("googleClientId" to config.googleClientId))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ConfigEndpoint for unauthenticated routes
- expose Google client ID via new endpoint

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6862b0c190a883219ae4f3069432e2b9