### PR TITLE
Return provider info from email-exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,14 @@ curl -X POST http://localhost:8080/auth/register \
   -d '{"username":"user","password":"password"}'
 ```
 
-You can check if an email is already registered:
+You can check if an email is already registered. If found, the authentication provider is returned:
 
 ```bash
 curl http://localhost:8080/auth/email-exists?email=user@example.com
+# {
+#   "exists": true,
+#   "provider": "LOCAL"
+# }
 ```
 
 ```bash

--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/EmailExistsResponse.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/EmailExistsResponse.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.thedome.domain.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EmailExistsResponse(
+    val exists: Boolean,
+    val provider: AuthProvider? = null
+)

--- a/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/AuthEndpoint.kt
@@ -17,6 +17,7 @@ import pl.cuyer.thedome.domain.auth.RefreshRequest
 import pl.cuyer.thedome.domain.auth.UpgradeRequest
 import pl.cuyer.thedome.domain.auth.GoogleAuthRequest
 import pl.cuyer.thedome.domain.auth.DeleteAccountRequest
+import pl.cuyer.thedome.domain.auth.EmailExistsResponse
 import pl.cuyer.thedome.exceptions.AnonymousUpgradeException
 import pl.cuyer.thedome.exceptions.InvalidCredentialsException
 import pl.cuyer.thedome.exceptions.InvalidRefreshTokenException
@@ -61,8 +62,8 @@ class AuthEndpoint(private val service: AuthService) {
                 get("/email-exists") {
                     val email = call.request.queryParameters["email"]
                         ?: return@get call.respond(HttpStatusCode.BadRequest)
-                    val exists = service.emailExists(email)
-                    call.respond(mapOf("exists" to exists))
+                    val provider = service.emailExists(email)
+                    call.respond(EmailExistsResponse(provider != null, provider))
                 }
                 post("/refresh") {
                     val req = call.receive<RefreshRequest>()

--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -227,8 +227,8 @@ class AuthService(
         return true
     }
 
-    suspend fun emailExists(email: String): Boolean {
-        return collection.find(eq(User::email, email)).firstOrNull() != null
+    suspend fun emailExists(email: String): AuthProvider? {
+        return collection.find(eq(User::email, email)).firstOrNull()?.provider
     }
 
     private fun generateAccessToken(user: User, validity: Long): String {

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
@@ -295,7 +295,7 @@ class AuthServiceTest {
 
         val result = service.emailExists("e@example.com")
 
-        assertTrue(result)
+        assertTrue(result == AuthProvider.LOCAL)
     }
 
     @Test
@@ -316,6 +316,6 @@ class AuthServiceTest {
 
         val result = service.emailExists("e@example.com")
 
-        assertTrue(!result)
+        assertTrue(result == null)
     }
 }


### PR DESCRIPTION
## Summary
- provide email provider info in AuthService
- expose provider via `/email-exists` endpoint
- add `EmailExistsResponse` model
- update service tests
- document provider info returned from `/email-exists`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68653319ca4083218ecff2da5a968ab3