### PR TITLE
Expose subscriber flag in auth tokens

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/TokenPair.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/TokenPair.kt
@@ -9,5 +9,6 @@ data class TokenPair(
     val refreshToken: String,
     val username: String,
     val email: String?,
-    val provider: AuthProvider
+    val provider: AuthProvider,
+    val subscriber: Boolean
 )

--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -66,7 +66,8 @@ class AuthService(
             refresh,
             username,
             email,
-            AuthProvider.LOCAL
+            AuthProvider.LOCAL,
+            user.subscriber
         )
     }
 
@@ -111,7 +112,8 @@ class AuthService(
             refresh,
             newUsername,
             updated.email,
-            AuthProvider.LOCAL
+            AuthProvider.LOCAL,
+            updated.subscriber
         )
     }
 
@@ -129,7 +131,8 @@ class AuthService(
             refresh,
             user.username,
             user.email,
-            user.provider
+            user.provider,
+            user.subscriber
         )
     }
 
@@ -185,7 +188,8 @@ class AuthService(
             refresh,
             user.username,
             user.email,
-            AuthProvider.GOOGLE
+            AuthProvider.GOOGLE,
+            user.subscriber
         )
     }
 
@@ -202,7 +206,8 @@ class AuthService(
             newRefresh,
             user.username,
             user.email,
-            user.provider
+            user.provider,
+            user.subscriber
         )
     }
 

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -411,6 +411,10 @@ components:
           type: string
         email:
           type: string
+        provider:
+          type: string
+        subscriber:
+          type: boolean
     AccessToken:
       type: object
       properties:

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceGoogleTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceGoogleTest.kt
@@ -55,6 +55,7 @@ class AuthServiceGoogleTest {
 
         assertTrue(result?.username == "google-sub1")
         assertTrue(result?.provider == AuthProvider.GOOGLE)
+        assertTrue(result?.subscriber == false)
         coVerify { collection.insertOne(match { it.googleId == "sub1" }, any<InsertOneOptions>()) }
     }
 }

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
@@ -85,6 +85,7 @@ class AuthServiceTest {
 
         assertTrue(result?.accessToken?.isNotEmpty() == true)
         assertTrue(result?.provider == AuthProvider.LOCAL)
+        assertTrue(result?.subscriber == false)
         coVerify(exactly = 4) { collection.updateOne(any<Bson>(), any<Bson>(), any()) }
     }
 
@@ -126,6 +127,7 @@ class AuthServiceTest {
         assertTrue(result?.username == "user")
         assertTrue(result?.email == "user@example.com")
         assertTrue(result?.provider == AuthProvider.LOCAL)
+        assertTrue(result?.subscriber == false)
         val expected = hash(result!!.refreshToken)
         assertTrue(slotUpdate.captured.toString().contains(expected))
         coVerify { tokenService.resubscribeUserTokens("user") }
@@ -168,6 +170,7 @@ class AuthServiceTest {
         assertTrue(result?.username == "user")
         assertTrue(result?.email == "user@example.com")
         assertTrue(result?.provider == AuthProvider.LOCAL)
+        assertTrue(result?.subscriber == false)
         val expectedFind = slotFind.captured.toString()
         assertTrue(expectedFind.contains(oldHash))
         val expectedUpdate = hash(result!!.refreshToken)


### PR DESCRIPTION
## Summary
- include `subscriber` field in `TokenPair`
- return subscription status from AuthService methods
- document new fields in OpenAPI spec
- verify subscriber field in authentication tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6865573b47b883218b589a1cb0e3ddd0