### PR TITLE
Add Google upgrade support

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/domain/auth/UpgradeRequest.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/auth/UpgradeRequest.kt
@@ -4,7 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class UpgradeRequest(
-    val username: String,
-    val password: String,
-    val email: String
+    val username: String? = null,
+    val password: String? = null,
+    val email: String? = null,
+    val token: String? = null
 )

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -438,3 +438,5 @@ components:
           type: string
         password:
           type: string
+        token:
+          type: string

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceTest.kt
@@ -88,7 +88,8 @@ class AuthServiceTest {
         assertTrue(result?.email == "user@example.com")
         assertTrue(result?.provider == AuthProvider.LOCAL)
         assertTrue(result?.subscribed == false)
-        coVerify(exactly = 5) { collection.updateOne(any<Bson>(), any<Bson>(), any()) }
+        coVerify(exactly = 6) { collection.updateOne(any<Bson>(), any<Bson>(), any()) }
+        coVerify { collection.updateOne(any<Bson>(), match<Bson> { it.toString().contains("testEndsAt") }, any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow `UpgradeRequest` to accept Google token
- add service method to upgrade anonymous accounts using Google
- update auth endpoint to handle Google-based upgrade
- remove `testEndsAt` when upgrading any anonymous account
- test Google upgrade

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686568c022e083218d488333ff17691b