### PR TITLE
Ensure unique usernames for Google logins

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/services/AuthService.kt
@@ -133,7 +133,8 @@ class AuthService(
 
         val googleId = info.subject
         val email = info.email
-        val name = info.name ?: info.givenName ?: "google-$googleId"
+        val baseName = info.name ?: info.givenName ?: "google"
+        val name = "${baseName}-$googleId"
 
         if (collection.find(eq(User::googleId, googleId)).firstOrNull() != null) return null
         if (email != null && collection.find(eq(User::email, email)).firstOrNull() != null) return null
@@ -190,7 +191,8 @@ class AuthService(
 
         val googleId = info.subject
         val email = info.email
-        val name = info.name ?: info.givenName ?: "google-$googleId"
+        val baseName = info.name ?: info.givenName ?: "google"
+        val name = "${baseName}-$googleId"
 
         // 1. Try to find user by googleId
         var user = collection.find(eq(User::googleId, googleId)).firstOrNull()

--- a/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceGoogleTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/AuthServiceGoogleTest.kt
@@ -72,7 +72,7 @@ class AuthServiceGoogleTest {
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val collection = mockk<MongoCollection<User>>(relaxed = true)
         val anon = User(username = "anon-1", provider = AuthProvider.ANONYMOUS, passwordHash = "", refreshToken = null)
-        val updated = anon.copy(username = "name", email = "u@example.com", googleId = "sub2", provider = AuthProvider.GOOGLE)
+        val updated = anon.copy(username = "name-sub2", email = "u@example.com", googleId = "sub2", provider = AuthProvider.GOOGLE)
         every { collection.find(any<Bson>()) } returnsMany listOf(
             FindFlow(SimpleFindPublisher(listOf(anon))),
             FindFlow(SimpleFindPublisher(emptyList())),
@@ -95,7 +95,7 @@ class AuthServiceGoogleTest {
 
         val result = service.upgradeAnonymousWithGoogle("anon-1", "token")
 
-        assertTrue(result?.username == "name")
+        assertTrue(result?.username == "name-sub2")
         assertTrue(result?.email == "u@example.com")
         assertTrue(result?.provider == AuthProvider.GOOGLE)
         assertTrue(result?.subscribed == false)


### PR DESCRIPTION
## Summary
- guarantee uniqueness of usernames when logging in with Google
- adjust Google auth upgrade test for new username format

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686580a8cb308321b8ecdb752b94a885