### PR TITLE
Send notifications asynchronously

### DIFF
--- a/src/main/kotlin/pl/cuyer/thedome/Application.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/Application.kt
@@ -50,6 +50,7 @@ import pl.cuyer.thedome.routes.AuthEndpoint
 import pl.cuyer.thedome.routes.FavouritesEndpoint
 import pl.cuyer.thedome.routes.SubscriptionsEndpoint
 import pl.cuyer.thedome.routes.FcmTokenEndpoint
+import pl.cuyer.thedome.routes.FcmAdminEndpoint
 import pl.cuyer.thedome.routes.ConfigEndpoint
 import io.ktor.server.plugins.ratelimit.*
 import kotlin.time.Duration.Companion.seconds
@@ -268,6 +269,7 @@ fun Application.module() {
     val favouritesEndpoint = FavouritesEndpoint(favouritesService)
     val subscriptionsEndpoint = SubscriptionsEndpoint(subscriptionsService)
     val fcmTokenEndpoint = FcmTokenEndpoint(fcmTokenService)
+    val fcmAdminEndpoint = FcmAdminEndpoint(fcmService, config.apiKey)
 
     routing {
         authEndpoint.register(this)
@@ -289,6 +291,7 @@ fun Application.module() {
             subscriptionsEndpoint.register(this)
             fcmTokenEndpoint.register(this)
         }
+        fcmAdminEndpoint.register(this)
         get("/metrics") { call.respondText(metricsRegistry.scrape()) }
         swaggerUI(path = "swagger")
     }

--- a/src/main/kotlin/pl/cuyer/thedome/domain/fcm/FcmTopicRequest.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/domain/fcm/FcmTopicRequest.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.thedome.domain.fcm
+
+import kotlinx.serialization.Serializable
+import pl.cuyer.thedome.services.NotificationType
+
+@Serializable
+data class FcmTopicRequest(
+    val topic: String,
+    val name: String,
+    val type: NotificationType,
+    val timestamp: String
+)

--- a/src/main/kotlin/pl/cuyer/thedome/routes/FcmAdminEndpoint.kt
+++ b/src/main/kotlin/pl/cuyer/thedome/routes/FcmAdminEndpoint.kt
@@ -1,0 +1,28 @@
+package pl.cuyer.thedome.routes
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import pl.cuyer.thedome.domain.fcm.FcmTopicRequest
+import pl.cuyer.thedome.services.FcmService
+
+class FcmAdminEndpoint(
+    private val service: FcmService,
+    private val apiKey: String
+) {
+    fun register(route: Route) {
+        with(route) {
+            post("/internal/notify") {
+                val key = call.request.header("X-Api-Key")
+                if (apiKey.isEmpty() || key != apiKey) {
+                    return@post call.respond(HttpStatusCode.Unauthorized)
+                }
+                val req = call.receive<FcmTopicRequest>()
+                service.sendToTopic(req.topic, req.name, req.type, req.timestamp)
+                call.respond(HttpStatusCode.Accepted)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/pl/cuyer/thedome/services/FcmServiceTest.kt
+++ b/src/test/kotlin/pl/cuyer/thedome/services/FcmServiceTest.kt
@@ -3,6 +3,7 @@ package pl.cuyer.thedome.services
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.Message
 import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.api.core.ApiFutures
 import com.google.auth.oauth2.GoogleCredentials
 import com.mongodb.kotlin.client.coroutine.MongoCollection
 import com.mongodb.kotlin.client.coroutine.FindFlow
@@ -30,6 +31,7 @@ class FcmServiceTest {
     @Test
     fun `checkAndSend sends message using firebase`() = runBlocking {
         val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        every { messaging.sendAsync(any()) } returns ApiFutures.immediateFuture("1")
         val credentials = mockk<GoogleCredentials>(relaxed = true)
         val tokenService = mockk<FcmTokenService>(relaxed = true)
         val now = Clock.System.now()
@@ -52,7 +54,7 @@ class FcmServiceTest {
 
         val captured = slot<Message>()
         verify { credentials.refreshIfExpired() }
-        verify { messaging.send(capture(captured)) }
+        verify { messaging.sendAsync(capture(captured)) }
         val message = captured.captured
         fun field(target: Any, name: String): Any? = target.javaClass.getDeclaredField(name).apply { isAccessible = true }.get(target)
         assertEquals("1", field(message, "topic"))
@@ -68,7 +70,7 @@ class FcmServiceTest {
         val exception = mockk<FirebaseMessagingException>()
         every { exception.message } returns "error"
         val messaging = mockk<FirebaseMessaging>()
-        every { messaging.send(any()) } throws exception
+        every { messaging.sendAsync(any()) } returns ApiFutures.immediateFailedFuture(exception)
         val credentials = mockk<GoogleCredentials>(relaxed = true)
         val tokenService = mockk<FcmTokenService>(relaxed = true)
         val now = Clock.System.now()
@@ -90,5 +92,41 @@ class FcmServiceTest {
         service.checkAndSend()
 
         coVerify(exactly = 0) { tokenService.removeToken(any(), any()) }
+    }
+
+    @Test
+    fun `checkAndSend sends for multiple servers`() = runBlocking {
+        val messaging = mockk<FirebaseMessaging>(relaxed = true)
+        every { messaging.sendAsync(any()) } returns ApiFutures.immediateFuture("1")
+        val credentials = mockk<GoogleCredentials>(relaxed = true)
+        val tokenService = mockk<FcmTokenService>(relaxed = true)
+        val now = Clock.System.now()
+        val server1 = BattlemetricsServerContent(
+            attributes = Attributes(
+                id = "a1",
+                name = "Server1",
+                details = Details(rustNextWipe = (now + 30.seconds).toString())
+            ),
+            id = "1"
+        )
+        val server2 = BattlemetricsServerContent(
+            attributes = Attributes(
+                id = "a2",
+                name = "Server2",
+                details = Details(rustNextWipe = (now + 30.seconds).toString())
+            ),
+            id = "2"
+        )
+        val serverColl = mockk<MongoCollection<BattlemetricsServerContent>>()
+        every { serverColl.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(server1, server2)))
+        val usersColl = mockk<MongoCollection<User>>()
+        val user = User(username = "user", passwordHash = "", subscriptions = listOf("1", "2"), fcmTokens = listOf(FcmToken("t1", "ts")))
+        every { usersColl.find(any<Bson>()) } returns FindFlow(SimpleFindPublisher(listOf(user)))
+
+        val service = FcmService(messaging, serverColl, listOf(1), emptyList(), credentials, usersColl, tokenService)
+
+        service.checkAndSend()
+
+        verify(exactly = 2) { messaging.sendAsync(any()) }
     }
 }


### PR DESCRIPTION
## Summary
- execute FCM sends concurrently with `sendAsync`
- expose endpoint to post internal notifications
- test concurrent FCM sends

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6866cb192fe08321bb5144561e9d0048